### PR TITLE
[FIX] check file exists before trying to read it

### DIFF
--- a/odoo/addons/base/ir/ir_attachment.py
+++ b/odoo/addons/base/ir/ir_attachment.py
@@ -94,13 +94,14 @@ class IrAttachment(models.Model):
     def _file_read(self, fname, bin_size=False):
         full_path = self._full_path(fname)
         r = ''
-        try:
-            if bin_size:
-                r = human_size(os.path.getsize(full_path))
-            else:
-                r = base64.b64encode(open(full_path,'rb').read())
-        except (IOError, OSError):
-            _logger.info("_read_file reading %s", full_path, exc_info=True)
+        if os.path.exists(full_path):
+            try:
+                if bin_size:
+                    r = human_size(os.path.getsize(full_path))
+                else:
+                    r = base64.b64encode(open(full_path,'rb').read())
+            except (IOError, OSError):
+                _logger.info("_read_file reading %s", full_path, exc_info=True)
         return r
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Checks that a file exists before trying to read it which prevents throwing unnecessary errors.

Current behavior before PR:
A mixture of FileNotFoundError and KeyError errors are thrown when rendering an email attachment which doesn't curren't exist via none ir.view methods.
 

Desired behavior after PR is merged:
No error is thrown and an empty string is returned as per the other fail states.

