### PR TITLE
Udes/1166

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1840,6 +1840,7 @@ class Many2one(_Relational):
         'ondelete': 'set null',         # what to do when value is deleted
         'auto_join': False,             # whether joins are generated upon search
         'delegate': False,              # whether self implements delegation
+        'index': True,                  # udes/1152 m2o index by default
     }
 
     def __init__(self, comodel_name=Default, string=Default, **kwargs):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1840,7 +1840,7 @@ class Many2one(_Relational):
         'ondelete': 'set null',         # what to do when value is deleted
         'auto_join': False,             # whether joins are generated upon search
         'delegate': False,              # whether self implements delegation
-        'index': True,                  # udes/1152 m2o index by default
+        'index': True,                  # udes/1166 m2o index by default
     }
 
     def __init__(self, comodel_name=Default, string=Default, **kwargs):


### PR DESCRIPTION
Adding index: true default for many2one field type.

Before: 
There were many fkeys without indexes.

After:
All m2o fkeys have indexes created by default
