### PR TITLE
[IMP] many2one fields to be indexed by default as per udes/1166

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1840,6 +1840,7 @@ class Many2one(_Relational):
         'ondelete': 'set null',         # what to do when value is deleted
         'auto_join': False,             # whether joins are generated upon search
         'delegate': False,              # whether self implements delegation
+        'index': True,                  # udes/1166 m2o index by default
     }
 
     def __init__(self, comodel_name=Default, string=Default, **kwargs):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
UDES story 1166, automatically indexing m2o fields

Current behavior before PR:
Indexes are off by default

Desired behaviour after PR is merged:
Index creation for m2o fields created by default