### PR TITLE
[IMP] fields: Index all Many2one columns by default

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1920,6 +1920,7 @@ class Many2one(_Relational):
         'ondelete': 'set null',         # what to do when value is deleted
         'auto_join': False,             # whether joins are generated upon search
         'delegate': False,              # whether self implements delegation
+        'index': True,                  # whether the field is indexed in database
     }
 
     def __init__(self, comodel_name=Default, string=Default, **kwargs):


### PR DESCRIPTION
Many2one columns are foreign keys, which are likely to be looked up
frequently (e.g. when enforcing database integrity constraints).
Index all such columns by default, since experience shows that the
impact of the occasional missing index on a foreign key column tends
to be substantially worse than the impact of unnecessary indexes on
infrequently used data.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>
