### PR TITLE
Batch delete

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -219,9 +219,6 @@ class StockQuant(models.Model):
                         'quantity': quant.quantity + quantity,
                         'in_date': in_date,
                     })
-                    # cleanup empty quants
-                    if float_is_zero(quant.quantity, precision_rounding=rounding) and float_is_zero(quant.reserved_quantity, precision_rounding=rounding):
-                        quant.unlink()
                     break
             except OperationalError as e:
                 if e.pgcode == '55P03':  # could not obtain the lock
@@ -323,6 +320,11 @@ class StockQuant(models.Model):
                 self.env.cr.execute(query)
         except Error as e:
             _logger.info('an error occured while merging quants: %s', e.pgerror)
+
+    @api.model
+    def delete_empty_quants(self):
+        self.search([('quantity', '=', 0),
+                     ('reserved_quantity', '=', 0)]).unlink()
 
 
 class QuantPackage(models.Model):

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -315,6 +315,7 @@ class StockQuant(TransactionCase):
     def test_decrease_available_quantity_2(self):
         """ Decrease the available quantity when multiple quants are already in a location.
         """
+        Quant = self.env['stock.quant']
         stock_location = self.env.ref('stock.stock_location_stock')
         product1 = self.env['product.product'].create({
             'name': 'Product A',
@@ -329,6 +330,7 @@ class StockQuant(TransactionCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product1, stock_location), 2.0)
         self.assertEqual(len(self.env['stock.quant']._gather(product1, stock_location)), 2)
         self.env['stock.quant']._update_available_quantity(product1, stock_location, -1.0)
+        Quant.delete_empty_quants()
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product1, stock_location), 1.0)
         self.assertEqual(len(self.env['stock.quant']._gather(product1, stock_location)), 1)
 
@@ -356,6 +358,7 @@ class StockQuant(TransactionCase):
         """ Decrease the available quantity that delete the quant. The active user should have
         read,write and unlink rights
         """
+        Quant = self.env['stock.quant']
         stock_location = self.env.ref('stock.stock_location_stock')
         product1 = self.env['product.product'].create({
             'name': 'Product A',
@@ -368,6 +371,7 @@ class StockQuant(TransactionCase):
         })
         self.env = self.env(user=self.demo_user)
         self.env['stock.quant']._update_available_quantity(product1, stock_location, -1.0)
+        Quant.delete_empty_quants()
         self.assertEqual(len(self.env['stock.quant']._gather(product1, stock_location)), 0)
 
     def test_increase_reserved_quantity_1(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Update picking validation to delete emptied quants in batch for efficiency.

Current behavior before PR:
Poorly thought out quant deletion behaviour is slooow.

Desired behavior after PR is merged:
quant deletion on picking validation is not as slow.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
