### PR TITLE
[FIX] stock: Make empty quants deletion use sudo

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -323,8 +323,8 @@ class StockQuant(models.Model):
 
     @api.model
     def delete_empty_quants(self):
-        self.search([('quantity', '=', 0),
-                     ('reserved_quantity', '=', 0)]).unlink()
+        self.sudo().search([('quantity', '=', 0),
+                            ('reserved_quantity', '=', 0)]).unlink()
 
 
 class QuantPackage(models.Model):


### PR DESCRIPTION
Signed-off-by: Michele Costa <michele.costa@unipart.io>

Description of the issue/feature this PR addresses:
delete_empty_quants causes some permission related errors
Current behavior before PR:
delete_empty_quants some permission related errors
Desired behavior after PR is merged:
delete_empty_quants does not cause permission related errors

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
