### PR TITLE
[IMP] stock: Propagate quantity changes to move_dest_ids

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1048,6 +1048,9 @@ class StockMove(models.Model):
                 # only cancel the next move if all my siblings are also cancelled
                 if all(state == 'cancel' for state in siblings_states):
                     move.move_dest_ids._action_cancel()
+                else:
+                    # but at least update quantities
+                    move._propagate_qty_to_next_move((0 - move.product_uom_qty))
             else:
                 if all(state in ('done', 'cancel') for state in siblings_states):
                     move.move_dest_ids.write({'procure_method': 'make_to_stock'})


### PR DESCRIPTION
When a move product_uom_qty is updated, propagate the difference to its
move_dest_ids, assuming only one is not in state done or cancel.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
