### PR TITLE
[FIX] stock: Products tracked by lots can reuse existing lot_id

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -366,7 +366,7 @@ class StockMoveLine(models.Model):
         intended to be called when editing a `done` move (that's what the override of `write` here
         is done.
         """
-
+        Lot = self.env['stock.production.lot']
         # First, we loop over all the move lines to do a preliminary check: `qty_done` should not
         # be negative and, according to the presence of a picking type or a linked inventory
         # adjustment, enforce some rules on the `lot_id` field. If `qty_done` is null, we unlink
@@ -393,10 +393,25 @@ class StockMoveLine(models.Model):
                             # the fly before assigning it to the move line if the user checked both
                             # `use_create_lots` and `use_existing_lots`.
                             if ml.lot_name and not ml.lot_id:
-                                lot = self.env['stock.production.lot'].create(
-                                    {'name': ml.lot_name, 'product_id': ml.product_id.id}
-                                )
-                                ml.write({'lot_id': lot.id})
+                                lot = None
+                                # If the product is tracked by lots, allow
+                                # to reuse an existing lot number
+                                if ml.product_id.tracking == 'lot':
+                                    lot = Lot.search([
+                                        ('name', '=', ml.lot_name),
+                                        ('product_id', '=', ml.product_id.id),
+                                    ])
+                                if not lot:
+                                    lot = Lot.create({
+                                        'name': ml.lot_name,
+                                        'product_id': ml.product_id.id,
+                                    })
+                                # find all the move lines with the same product
+                                # and lot_name and update them in batch
+                                mls = self.filtered(
+                                    lambda x: x.product_id == ml.product_id \
+                                              and x.lot_name == ml.lot_name)
+                                mls.write({'lot_id': lot.id})
                         elif not picking_type_id.use_create_lots and not picking_type_id.use_existing_lots:
                             # If the user disabled both `use_create_lots` and `use_existing_lots`
                             # checkboxes on the picking type, he's allowed to enter tracked


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Same lot number cannot be used to receive stock multiple times for the same product.

Current behavior before PR:
Using the same lot number twice, either because the product is in different packages or
because it is received in multiple pickings, raises an error that the combination of
lot number and product should be unique.

Desired behavior after PR is merged:
Allow to use existing lots when receiving products tracked by lot and
to use the same lot number for the same product in multiple packages.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
