### PR TITLE
[FIX] stock: Use correct quantity field of stock quant

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -492,5 +492,5 @@ class QuantPackage(models.Model):
         for quant in self._get_contained_quants():
             if quant.product_id not in res:
                 res[quant.product_id] = 0
-            res[quant.product_id] += quant.qty
+            res[quant.product_id] += quant.quantity
         return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
stock.quant.package.get_content() function uses an unexisting stock.quant field: qty, which it should be quantity.

Current behavior before PR:
An error is raise when trying to get content of a package.

Desired behavior after PR is merged:
The content of the package is properly returned.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
