### PR TITLE
[FIX] sale_stock: Propagate sale order line on procurement rules

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -26,6 +26,12 @@ class StockMove(models.Model):
         keys_sorted.append(move.sale_line_id.id)
         return keys_sorted
 
+    def _prepare_procurement_values(self):
+        values = super(StockMove, self)._prepare_procurement_values()
+        if self.sale_line_id:
+            values['sale_line_id'] = self.sale_line_id.id
+        return values
+
     def _action_done(self):
         result = super(StockMove, self)._action_done()
         for line in result.mapped('sale_line_id').sudo():


### PR DESCRIPTION
Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>

Description of the issue/feature this PR addresses:
Stock moves created by procurement rules when having more than one stage in the route are not getting the sale order line field, only the first stock move has it.

Current behavior before PR:
Stock moves created by procurement rules are not getting the sale order line field from the first move.

Desired behavior after PR is merged:
All stock moves created by procurement rules also get the sale order line field.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
