### PR TITLE
[IMP] stock: Recompute state of next move when propagating quantity

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -405,6 +405,7 @@ class StockMove(models.Model):
             # Use do_not_unreserve = True flag to avoid unreserving stock for
             # partially available moves
             next_move.with_context(do_not_unreserve=True).write(vals)
+            next_move._recompute_state()
 
     def write(self, vals):
         # FIXME: pim fix your crap


### PR DESCRIPTION
Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>

Description of the issue/feature this PR addresses:
Changing the quantity of the next move should recompute its state.

Current behavior before PR:
State of the next move remains the same, for instance it does not change from partially available to assigned.

Desired behavior after PR is merged:
State of the next move changes to the proper one, for instance it changes from partially available to assigned.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
