### PR TITLE
[IMP] http: Creating a new session for any successful login

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1036,6 +1036,17 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
             uid = dispatch_rpc('common', 'authenticate', [db, login, password, env])
         else:
             security.check(db, uid, password)
+
+        # udes-11.0
+        # Session fixation:
+        # If the user has successfully logged in, forcefully create a new
+        # session as part of this request. This prevents session hijacking
+        # prior to authentication being effective.
+        if uid:
+            request.httprequest.session = root.session_store.new()
+            self = request.httprequest.session
+        # end udes-11.0
+
         self.db = db
         self.uid = uid
         self.login = login


### PR DESCRIPTION
Session fixation - if a session ID is retained on login, any
hijacked sessions prior to authentication will be upgraded to
logged in sessions. Swapping the sessionID on successful login
ensures that a logged in user is given a fresh session.

Description of the issue/feature this PR addresses:
Session fixation

Current behavior before PR:
Session ID is retained on login, allowing potential attackers to.

Desired behavior after PR is merged:
Session ID is changed on login, preventing hijacked sessions 
from being upgraded to logged in sessions.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
