### PR TITLE
[FIX] Update request.session when swapping sessions

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1044,6 +1044,7 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
         # prior to authentication being effective.
         if uid:
             request.httprequest.session = root.session_store.new()
+            request.session = request.httprequest.session
             self = request.httprequest.session
         # end udes-11.0
 


### PR DESCRIPTION
When preventing session fixation we must also update the request.session
with the new one.

Current behavior before PR:
request.session not updated

Desired behavior after PR is merged:
request.session updated

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
