### PR TITLE
[ADD] unittests: output test results as XML

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -161,6 +161,8 @@ class configmanager(object):
                          my_default=False, help="Enable YAML and unit tests.")
         group.add_option("--test-commit", action="store_true", dest="test_commit",
                          my_default=False, help="Commit database changes performed by YAML or XML tests.")
+        group.add_option("--test-xml-file", dest="test_xml_file", my_default=False,
+                         help="Save the unittest results to a XML file.")
         parser.add_option_group(group)
 
         # Logging Group
@@ -425,7 +427,7 @@ class configmanager(object):
             'dev_mode', 'shell_interface', 'smtp_ssl', 'load_language',
             'stop_after_init', 'logrotate', 'without_demo', 'http_enable', 'syslog',
             'list_db', 'proxy_mode',
-            'test_file', 'test_enable', 'test_commit', 'test_report_directory',
+            'test_file', 'test_enable', 'test_commit', 'test_report_directory', 'test_xml_file',
             'osv_memory_count_limit', 'osv_memory_age_limit', 'max_cron_threads', 'unaccent',
             'data_dir',
             'server_wide_modules',


### PR DESCRIPTION
Allow the unittest results to be output as XML for integration with
Jenkins.

User-story: 3110
Task: 3229

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>