### PR TITLE
[FIX]: addons/mail: remove unnecessary cache invalidations

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -876,9 +876,4 @@ class Message(models.Model):
 
         channels_sudo._notify(self)
 
-        # Discard cache, because child / parent allow reading and therefore
-        # change access rights.
-        if self.parent_id:
-            self.parent_id.invalidate_cache()
-
         return True

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2027,7 +2027,6 @@ class MailThread(models.AbstractModel):
         for record in self.filtered(lambda self: self.id in part):
             record.write({'message_follower_ids': part[record.id]})
 
-        self.invalidate_cache()
         return True
 
     @api.multi


### PR DESCRIPTION
The cache is being invalidated whenever a notification is sent or a
thread is subscribed to. This is causing problems when it occurs every
time an object is created (e.g. stock.picking.batch).
The original commits that introduced these lines appear to be based on a
different cache model used by OpenERP.

User-story: 3539
Task: 3540

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>
