### PR TITLE
[FIX] stock: Clear partially_available flag on moves when they are assigned

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -138,7 +138,7 @@ class Quant(models.Model):
         # TDE CLEANME: should be moved as a move model method IMO
         rounding = move.product_id.uom_id.rounding
         if float_compare(reserved_availability, move.product_qty, precision_rounding=rounding) == 0 and move.state in ('confirmed', 'waiting'):
-            move.write({'state': 'assigned'})
+            move.write({'state': 'assigned', 'partially_available': False})
         elif float_compare(reserved_availability, 0, precision_rounding=rounding) > 0 and not move.partially_available:
             move.write({'partially_available': True})
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Ensures that pickings with fully assigned moves do not remain partially available incorrectly.

Current behavior before PR:
Under some circumstances `action_assign` will leave moves both `assigned` and `partially_available`, which makes pickings containing those moves end up partially available instead of available.

Desired behavior after PR is merged:
moves will no longer end up both `assigned` and `partially_available` simultaneously as a result of `action_assign`.
