### PR TITLE
[IMP] stock: Modify stock.picking's do_unreserve to be batched

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -706,8 +706,7 @@ class Picking(models.Model):
 
     @api.multi
     def do_unreserve(self):
-        for picking in self:
-            picking.move_lines._do_unreserve()
+        self.mapped('move_lines')._do_unreserve()
 
     @api.multi
     def button_validate(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Performance improvement when unreserving multiple pickings at the same time.

Current behavior before PR:
Bulk-unreserving 80 pickings with a single move each takes about 10 seconds

Desired behavior after PR is merged:
Bulk-unreserving pickings takes less time



