### PR TITLE
[WIP] udes_stock: Cancelling a picking doesn't recompute stock move s…

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1073,7 +1073,7 @@ class StockMove(models.Model):
         for move in self:
             if move.state == 'cancel':
                 continue
-            move._do_unreserve()
+            move.with_context(recompute_state=False)._do_unreserve()
             siblings_states = (move.move_dest_ids.mapped('move_orig_ids') - move).mapped('state')
             if move.propagate:
                 # only cancel the next move if all my siblings are also cancelled

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -353,7 +353,8 @@ class StockMoveLine(models.Model):
                         raise
         moves = self.mapped('move_id')
         res = super(StockMoveLine, self).unlink()
-        if moves:
+        recompute_state = self.env.context.get('recompute_state', True)
+        if moves and recompute_state:
             moves._recompute_state()
         return res
 


### PR DESCRIPTION
…tate

Context variable passed in to bypass recomputing the state on cancelled pickings. We know what state the picking needs to be in, hence recomputing the state of the picking is redundant.

Story/4059

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
