### PR TITLE
[FIX] Prevent XSS when uploading attachments

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -3,6 +3,7 @@
 
 import babel.messages.pofile
 import base64
+import cgi
 import csv
 import datetime
 import functools
@@ -1032,15 +1033,16 @@ class Binary(http.Controller):
                     win.jQuery(win).trigger(%s, %s);
                 </script>"""
         try:
+            filename = cgi.escape(ufile.filename, quote=True)
             attachment = Model.create({
-                'name': ufile.filename,
+                'name': filename,
                 'datas': base64.encodestring(ufile.read()),
-                'datas_fname': ufile.filename,
+                'datas_fname': filename,
                 'res_model': model,
                 'res_id': int(id)
             })
             args = {
-                'filename': ufile.filename,
+                'filename': filename,
                 'mimetype': ufile.content_type,
                 'id':  attachment.id
             }


### PR DESCRIPTION
Use html.escape() to escape special characters to prevent XSS attacks.

This is a backport of story/4113 9813b692a058f6717aee6b3c2919f512345ed327.

Task: 4550
User-story: 4407

Signed-off-by: Sean Quah <sean.quah@unipart.io>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
