### PR TITLE
wip: [IMP] odoo: Do not write values to recordsets if there is no change

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -284,6 +284,7 @@ class Field(MetaField('DummyField', (object,), {})):
         'comodel_name': None,           # name of the model of values (if relational)
 
         'store': True,                  # whether the field is stored in database
+        'force_write': False,           # whether we should write to this record even if nothing changes
         'index': False,                 # whether the field is indexed in database
         'manual': False,                # whether the field is a custom field
         'copy': True,                   # whether the field is copied over by BaseModel.copy()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When loading Odoo data, writes occur to records even
if no data has changed, this causes recomputes and in
the specific case of stock.location.name can take a huge
time to upgrade.

Current behaviour before PR:
Odoo will write() a record even if nothing changes

Desired behaviour after PR is merged:
Odoo check's the recordset it's writing to, if no change
is detected it will not write



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
