### PR TITLE
[FIX] odoo: Do not convert empty binary strings into NULLs

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1654,10 +1654,12 @@ class Binary(Field):
         # unicode in some circumstances, hence the str() cast here.
         # This str() coercion will only work for pure ASCII unicode strings,
         # on purpose - non base64 data must be passed as a 8bit byte strings.
-        if not value:
-            return None
         if isinstance(value, bytes):
             return psycopg2.Binary(value)
+        if isinstance(value, pycompat.text_type):
+            return psycopg2.Binary(value.encode('ascii'))
+        if not value:
+            return None
         return psycopg2.Binary(pycompat.text_type(value).encode('ascii'))
 
     def convert_to_cache(self, value, record, validate=True):


### PR DESCRIPTION
This ensures that uploads of empty attachments behave consistently with
non-empty attachments.

Task: 4467
User-story: 3496

Signed-off-by: Sean Quah <sean.quah@unipart.io>

Description of the issue/feature this PR addresses:
`write()` replaces `b""` with `NULL` for binary fields which causes issues for empty attachments.

Current behavior before PR:
`write()` replaces `b""` with `NULL` for binary fields

Desired behavior after PR is merged:
`write()` doesn't mangle empty strings in binary fields.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
