### PR TITLE
[IMP] odoo: Improve write_modified when writing falsey values

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -8,7 +8,7 @@ class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'
 
     manufacture_to_resupply = fields.Boolean(
-        'Manufacture in this Warehouse', default=True,
+        'Manufacture in this Warehouse', default=True, force_write=True,
         help="When products are manufactured, they can be manufactured in this warehouse.")
     manufacture_pull_id = fields.Many2one(
         'procurement.rule', 'Manufacture Rule')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -285,6 +285,7 @@ class Field(MetaField('DummyField', (object,), {})):
 
         'store': True,                  # whether the field is stored in database
         'index': False,                 # whether the field is indexed in database
+        'force_write': False,           # Whether the field should be written in write_modified regardless of whether there are changes
         'manual': False,                # whether the field is a custom field
         'copy': True,                   # whether the field is copied over by BaseModel.copy()
         'depends': (),                  # collection of field dependencies

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2986,7 +2986,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # Loop records and values to find out what we expect to be modified
         for record in self:
             for key, val in vals.items():
-                if fields[key] and val:
+                if fields[key]:
                     # If a many2many or one2many field is being written,
                     # just write normally.
                     if fields[key].type in ('many2many', 'one2many'):
@@ -2997,10 +2997,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     # just write normally
                     if isinstance(current_value, BaseModel):
                         current_value = current_value.id
-                        if current_value != val:
+                        if (val or current_value) and current_value != val:
                             return self.write(vals)
                     # If different, store record with set of value keys
-                    if current_value != val:
+                    if (val or current_value) and current_value != val:
                         records_with_changes[record].add(key)
                 else:
                     # If the field doesn't exist, we write anyway

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2986,7 +2986,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # Loop records and values to find out what we expect to be modified
         for record in self:
             for key, val in vals.items():
-                if fields[key]:
+                if fields[key] and not fields[key].force_write:
                     # If a many2many or one2many field is being written,
                     # just write normally.
                     if fields[key].type in ('many2many', 'one2many'):


### PR DESCRIPTION
When writing falsey values we can still remove them from being
written, this reduces unnecessary writes and recomputes further.