### PR TITLE
[REF] odoo: Use a non-absolute path for login page redirects

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -780,7 +780,7 @@ class HttpRequest(WebRequest):
                 request.session.save_request_data()
                 redirect = '/web/proxy/post{r.full_path}'.format(r=req)
             elif not request.params.get('noredirect'):
-                redirect = req.url
+                redirect = req.path
             if redirect:
                 query = werkzeug.urls.url_encode({
                     'redirect': redirect,


### PR DESCRIPTION
eg. Redirect to /web/session/foo instead of https://domain/web/session/foo

Task: 4800
User-story: 98

Signed-off-by: Sean Quah <sean.quah@unipart.io>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
