### PR TITLE
[REF] odoo: UX fixes and refinements for session expiry

### DIFF
--- a/addons/web/static/src/js/core/misc.js
+++ b/addons/web/static/src/js/core/misc.js
@@ -143,8 +143,12 @@ function HistoryBack (parent) {
 }
 core.action_registry.add("history_back", HistoryBack);
 
-function login() {
-    redirect('/web/login');
+function login(redirectUrl) {
+    if (redirectUrl) {
+        redirect('/web/login?redirect=' + encodeURIComponent(redirectUrl));
+    } else {
+        redirect('/web/login');
+    }
 }
 core.action_registry.add("login", login);
 

--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -56,7 +56,10 @@ var CrashManager = core.Class.extend({
             return;
         }
         if (error.data.name === "odoo.http.SessionExpiredException" || error.data.name === "werkzeug.exceptions.Forbidden") {
-            this.show_warning({type: _t("Odoo Session Expired"), data: {message: _t("Your Odoo session expired. Please refresh the current web page.")}});
+            var login = core.action_registry.get("login");
+            login(window.location.pathname +
+                  window.location.search +
+                  window.location.hash);
             return;
         }
         if (_.has(map_title, error.data.exception_type)) {

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -780,7 +780,7 @@ class HttpRequest(WebRequest):
                 request.session.save_request_data()
                 redirect = '/web/proxy/post{r.full_path}'.format(r=req)
             elif not request.params.get('noredirect'):
-                redirect = req.url
+                redirect = req.path
             if redirect:
                 query = werkzeug.urls.url_encode({
                     'redirect': redirect,


### PR DESCRIPTION
[IMP] odoo: Redirect to the login page when session expiry is detected

This replaces the dialog that prompts the user to refresh the page manually
and provides a better user experience.

Task: 4787
User-story: 98

Signed-off-by: Sean Quah <sean.quah@unipart.io>

[REF] odoo: Use a non-absolute path for login page redirects

eg. Redirect to /web/session/foo instead of https://domain/web/session/foo

Task: 4800
User-story: 98

Signed-off-by: Sean Quah <sean.quah@unipart.io>


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
