### PR TITLE
[FIX] base: Improve protection for USER_PRIVATE_FIELDS

### DIFF
--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -208,7 +208,7 @@ class Partner(models.Model):
         compute='_compute_company_type', inverse='_write_company_type')
     company_id = fields.Many2one('res.company', 'Company', index=True, default=_default_company)
     color = fields.Integer(string='Color Index', default=0)
-    user_ids = fields.One2many('res.users', 'partner_id', string='Users', auto_join=True)
+    user_ids = fields.One2many('res.users', 'partner_id', string='Users')
     partner_share = fields.Boolean(
         'Share Partner', compute='_compute_partner_share', store=True,
         help="Either customer (no user), either shared user. Indicated the current partner is a customer without "

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -330,7 +330,7 @@ class Users(models.Model):
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        groupby_fields = set([groupby] if isinstance(groupby, pycompat.string_types) else groupby)
+        groupby_fields = set([x.split(':')[0] for x in ([groupby] if isinstance(groupby, pycompat.string_types) else groupby)])
         if groupby_fields.intersection(USER_PRIVATE_FIELDS):
             raise AccessError(_("Invalid 'group by' parameter"))
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -306,6 +306,16 @@ class Users(models.Model):
         if action_open_website and any(user.action_id.id == action_open_website.id for user in self):
             raise ValidationError(_('The "App Switcher" action cannot be selected as home action.'))
 
+    def _check_qorder(self, order):
+        if self._uid != SUPERUSER_ID:
+            order_fields = [order.strip().split(' ')[0].split(':')[0]
+                            for order in order.split(',')]
+            order_fields = set(order_fields)
+            if order_fields.intersection(USER_PRIVATE_FIELDS):
+                raise AccessError(_("Invalid 'order' parameter"))
+
+        return super(Users, self)._check_qorder(order)
+
     @api.multi
     def read(self, fields=None, load='_classic_read'):
         if fields and self == self.env.user:

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -326,13 +326,13 @@ class Users(models.Model):
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
 
     @api.model
-    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
-        if self._uid != SUPERUSER_ID and args:
-            domain_fields = {term[0] for term in args if isinstance(term, (tuple, list))}
+    def _where_calc(self, domain, *args, **kwargs):
+        if self._uid != SUPERUSER_ID:
+            domain_fields = {term[0] for term in domain if isinstance(term, (tuple, list))}
             if domain_fields.intersection(USER_PRIVATE_FIELDS):
                 raise AccessError(_('Invalid search criterion'))
-        return super(Users, self)._search(args, offset=offset, limit=limit, order=order, count=count,
-                                          access_rights_uid=access_rights_uid)
+
+        return super(Users, self)._where_calc(domain, *args, **kwargs)
 
     @api.model
     def create(self, vals):

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -634,6 +634,27 @@ class Users(models.Model):
     def get_company_currency_id(self):
         return self.env.user.company_id.currency_id.id
 
+class UsersAutoJoinCheck(models.TransientModel):
+    """Remove auto_join from relations linking to res.users for security.
+
+       This lives in its own model since some third-party modules
+       override _register_hook for res.users and do not call super()."""
+
+    _name = 'res.users.auto_join_check'
+
+    @api.model_cr
+    def _register_hook(self):
+        super(UsersAutoJoinCheck, self)._register_hook()
+
+        for model_name, model in self.env.items():
+            for field_name, field in model._fields.items():
+                if (field.comodel_name == 'res.users' and
+                    field.auto_join):
+                    _logger.error('%s %s had auto_join onto res.users, '
+                                  'which bypasses security for private fields.',
+                                  model_name, field_name)
+                    field.auto_join = False
+
 #
 # Implied groups
 #


### PR DESCRIPTION
[FIX] base: Move check for user private fields in domains into _where_calc

Move the check for usage of res.users private fields in domains from
_search to _where_calc, so that it applies to domains specified in
read_group as well.

Task: 8525  
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Log and disable auto_joins onto res.users

Log and disable auto_joins onto res.users to prevent bypassing of security
for private fields.

Task: 8527  
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Remove auto_join from res.partner's user_ids

auto_join bypasses security checks on res.users' private fields, which
is undesirable.

Task: 8526
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Disallow use of res.users private fields in order by clauses

Task: 8528
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
