### PR TITLE
[FIX] base: Improve protection for USER_PRIVATE_FIELDS

### DIFF
--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -204,7 +204,7 @@ class Partner(models.Model, FormatAddress):
         compute='_compute_company_type', readonly=False)
     company_id = fields.Many2one('res.company', 'Company', index=True, default=_default_company)
     color = fields.Integer(string='Color Index', default=0)
-    user_ids = fields.One2many('res.users', 'partner_id', string='Users', auto_join=True)
+    user_ids = fields.One2many('res.users', 'partner_id', string='Users')
     partner_share = fields.Boolean(
         'Share Partner', compute='_compute_partner_share', store=True,
         help="Either customer (no user), either shared user. Indicated the current partner is a customer without "

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -320,7 +320,7 @@ class Users(models.Model):
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        groupby_fields = set([groupby] if isinstance(groupby, basestring) else groupby)
+        groupby_fields = set([x.split(':')[0] for x in ([groupby] if isinstance(groupby, basestring) else groupby)])
         if groupby_fields.intersection(USER_PRIVATE_FIELDS):
             raise AccessError(_("Invalid 'group by' parameter"))
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -316,13 +316,13 @@ class Users(models.Model):
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
 
     @api.model
-    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
-        if self._uid != SUPERUSER_ID and args:
-            domain_fields = {term[0] for term in args if isinstance(term, (tuple, list))}
+    def _where_calc(self, domain, *args, **kwargs):
+        if self._uid != SUPERUSER_ID:
+            domain_fields = {term[0] for term in domain if isinstance(term, (tuple, list))}
             if domain_fields.intersection(USER_PRIVATE_FIELDS):
                 raise AccessError(_('Invalid search criterion'))
-        return super(Users, self)._search(args, offset=offset, limit=limit, order=order, count=count,
-                                          access_rights_uid=access_rights_uid)
+
+        return super(Users, self)._where_calc(domain, *args, **kwargs)
 
     @api.model
     def create(self, vals):

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -296,6 +296,16 @@ class Users(models.Model):
         if any(user.company_ids and user.company_id not in user.company_ids for user in self):
             raise ValidationError(_('The chosen company is not in the allowed companies for this user'))
 
+    def _check_qorder(self, order):
+        if self._uid != SUPERUSER_ID:
+            order_fields = [order.strip().split(' ')[0].split(':')[0]
+                            for order in order.split(',')]
+            order_fields = set(order_fields)
+            if order_fields.intersection(USER_PRIVATE_FIELDS):
+                raise AccessError(_("Invalid 'order' parameter"))
+
+        return super(Users, self)._check_qorder(order)
+
     @api.multi
     def read(self, fields=None, load='_classic_read'):
         if fields and self == self.env.user:


### PR DESCRIPTION
Backport of https://github.com/unipartdigital/odoo/pull/46

--------------------------------

[FIX] base: Move check for user private fields in domains into _where_calc

Move the check for usage of res.users private fields in domains from
_search to _where_calc, so that it applies to domains specified in
read_group as well.

Task: 8525  
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Log and disable auto_joins onto res.users

Log and disable auto_joins onto res.users to prevent bypassing of security
for private fields.

Task: 8527  
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Remove auto_join from res.partner's user_ids

auto_join bypasses security checks on res.users' private fields, which
is undesirable.

Task: 8526
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

--------------------------------

[FIX] base: Disallow use of res.users private fields in order by clauses

Task: 8528
User-story: 4556

Signed-off-by: Sean Quah <sean.quah@unipart.io>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
