### PR TITLE
[FIX] account: Set default values for new invoices before performing onchanges

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -447,6 +447,7 @@ class AccountInvoice(models.Model):
 
     @api.model
     def create(self, vals):
+        vals = self._add_missing_default_values(vals)
         onchanges = {
             '_onchange_partner_id': ['account_id', 'payment_term_id', 'fiscal_position_id', 'partner_bank_id'],
             '_onchange_journal_id': ['currency_id'],


### PR DESCRIPTION
Account Invoices are unusual in that `create()` manually triggers `onchange`
methods. However, `onchange` methods typically rely on certain fields being
set, which may (and do in this case) only get their values from their `default`
function.

The Invoice `create()` method triggers `onchanges` *before* calling
`super().create()`, which means that default values were not being filled
at the right time; this change fixes that by explicitly filling in default values
(using the same method that `BaseModel.create()` uses) before this.