### PR TITLE
[IMP] stock: Ignore state done of siblings in _action_cancel()

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1076,9 +1076,11 @@ class StockMove(models.Model):
             move._do_unreserve()
             siblings_states = (move.move_dest_ids.mapped('move_orig_ids') - move).mapped('state')
             if move.propagate:
-                # only cancel the next move if all my siblings are also cancelled
-                if all(state == 'cancel' for state in siblings_states):
-                    move.move_dest_ids._action_cancel()
+                # only cancel the next move if all my siblings are done or cancelled
+                if all(state in ['cancel', 'done'] for state in siblings_states):
+                    # only cancel not done moves
+                    move.move_dest_ids.filtered(
+                        lambda m: m.state != 'done')._action_cancel()
                 else:
                     # but at least update quantities
                     move._propagate_qty_to_next_move((0 - move.product_uom_qty))


### PR DESCRIPTION
Moves in terminal state are ignored when checking if the following
moves have to be cancelled or reduce their quantity.

User-story: 8940

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
