### PR TITLE
[FIX] stock: Bypass reservation update at _check_entire_pack

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -702,7 +702,10 @@ class Picking(models.Model):
             origin_packages = picking.move_line_ids.mapped("package_id")
             for pack in origin_packages:
                 if picking._check_move_lines_map_quant_package(pack):
-                    picking.move_line_ids.filtered(lambda ml: ml.package_id == pack).write({'result_package_id': pack.id})
+                    picking.move_line_ids\
+                        .filtered(lambda ml: ml.package_id == pack)\
+                        .with_context(bypass_reservation_update=True)\
+                        .write({'result_package_id': pack.id})
 
     @api.multi
     def do_unreserve(self):


### PR DESCRIPTION
Updating the result package of move lines at _check_entire_pack
of a picking should not trigger any reservation update code.

User-story: 9124

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>

