### PR TITLE
[FIX] odoo: Create new session on login;

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1000,6 +1000,18 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
             uid = odoo.registry(db)['res.users'].authenticate(db, login, password, env)
         else:
             security.check(db, uid, password)
+
+        # udes-13.0
+        # Session fixation:
+        # If the user has successfully logged in, forcefully create a new
+        # session as part of this request. This prevents session hijacking
+        # prior to authentication being effective.
+        if uid:
+            request.httprequest.session = root.session_store.new()
+            request.session = request.httprequest.session
+            self = request.httprequest.session
+        # end udes-13.0 session fixation change
+
         self.rotate = True
         self.db = db
         self.uid = uid


### PR DESCRIPTION
Creating a new session on login tackles removes session fixation,
preventing a hijacked logged out session being upgraded to a
logged in one. This reduces the number of ways an attacker can
hijack a logged in session. This is something many pen tests will
test against.

Description of the issue/feature this PR addresses:
Session fixation

Current behavior before PR:
Session ID is retained on login

Desired behavior after PR is merged:
Session ID changes when user logs in



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
