### PR TITLE
[FIX] web: Fixed vulnerability to XSS when uploading attachments

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -8,6 +8,7 @@ import datetime
 import functools
 import glob
 import hashlib
+import html
 import io
 import itertools
 import jinja2
@@ -1495,11 +1496,11 @@ class Binary(http.Controller):
         args = []
         for ufile in files:
 
-            filename = ufile.filename
+            filename = html.escape(ufile.filename, quote=True)
             if request.httprequest.user_agent.browser == 'safari':
                 # Safari sends NFD UTF-8 (where é is composed by 'e' and [accent])
                 # we need to send it the same stuff, otherwise it'll fail
-                filename = unicodedata.normalize('NFD', ufile.filename)
+                filename = unicodedata.normalize('NFD', filename)
 
             try:
                 attachment = Model.create({


### PR DESCRIPTION
Story/9491

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>

Description of the issue/feature this PR addresses:
The upload_attachment endpoint can be used to inject malicious JS code in the form of an XSS attack.

Desired behavior after PR is merged:
The `name` field is properly escaped.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
