### PR TITLE
[FIX] web: Fixed vulnerability to XSS when opening a calendar item popup

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -274,12 +274,13 @@ var CalendarController = AbstractController.extend({
         }
 
         var open_dialog = function (readonly) {
+            var view_title = self.displayName || 'Calendar Entry';
             var options = {
                 res_model: self.modelName,
                 res_id: id || null,
                 context: event.context || self.context,
                 readonly: readonly,
-                title: _t("Open: ") + event.data.title,
+                title: _t("Open: ") + view_title,
                 on_saved: function () {
                     if (event.data.on_save) {
                         event.data.on_save();


### PR DESCRIPTION
Take the current menu name as the heading for the calendar item popup instead of the event title in the calendar view. The event title for each event is simply the first field set in the calendar view. This means if the first field is a text/char field it can include Javascript which will run when the popup is opened. By replacing this with the menu name this security issue can be avoided.

Story/9773

Signed-off-by: Peter Clark <peter.clark@unipart.io>
