### PR TITLE
[REF] odoo: Improve Many2one performance

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -451,6 +451,25 @@ def select_distinct_from_where_not_null(cr, select_field, from_table):
     cr.execute('SELECT distinct("%s") FROM "%s" where "%s" is not null' % (select_field, from_table, select_field))
     return [r[0] for r in cr.fetchall()]
 
+
+def select_where_exists(cr, from_table, select_field, fk_table, fk_field):
+    """Execute an EXISTS subquery to identify rows with children.
+
+    This is (theoretically) faster than SELECT DISTINCT for large datasets.
+    """
+    # The apparently redundant OFFSET 0 stops Postgres from inlining the
+    # subquery, which may result in a sub-optimal query plan.
+    # https://stackoverflow.com/questions/14897816/how-can-i-prevent-postgres-from-inlining-a-subquery
+    stmt = """SELECT "%s"."%s" FROM "%s"
+                WHERE EXISTS (SELECT 1 FROM "%s"
+                                WHERE "%s"."%s" = "%s"."%s" OFFSET 0)
+    """
+    cr.execute(stmt %
+               (from_table, select_field, from_table, fk_table,
+                from_table, select_field, fk_table, fk_field))
+    return [r[0] for r in cr.fetchall()]
+
+
 def get_unaccent_wrapper(cr):
     if odoo.registry(cr.dbname).has_unaccent:
         return lambda x: "unaccent(%s)" % (x,)
@@ -977,7 +996,7 @@ class expression(object):
                 else:
                     # determine ids1 = records with lines
                     if comodel._fields[field.inverse_name].store and not (inverse_is_int and domain):
-                        ids1 = select_distinct_from_where_not_null(cr, field.inverse_name, comodel._table)
+                        ids1 = select_where_exists(cr, model._table, "id", comodel._table, field.inverse_name)
                     else:
                         comodel_domain = [(field.inverse_name, '!=', False)]
                         if inverse_is_int and domain:


### PR DESCRIPTION
User-story/9977
Task/10012

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

For domain criteria of the form

`(Many2one, '=', False)`

the expression parser may execute a SELECT DISTINCT query to identify
parent rows that have child rows.  This query is expensive on large
datasets.

This patch replaces the SELECT DISTINCT query with a faster EXISTS
query.

TODO: similar SELECT DISTINCT in Many2many

