### PR TITLE
Packages fix

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -918,6 +918,120 @@ class TestX2many(common.TransactionCase):
         self.assertEqual(result, recs - recZ)
 
 
+class TestX2many(common.TransactionCase):
+    def test_search_many2many(self):
+        """ Tests search on many2many fields. """
+        tags = self.env['test_new_api.multi.tag']
+        tagA = tags.create({})
+        tagB = tags.create({})
+        tagC = tags.create({})
+        recs = self.env['test_new_api.multi.line']
+        recW = recs.create({})
+        recX = recs.create({'tags': [(4, tagA.id)]})
+        recY = recs.create({'tags': [(4, tagB.id)]})
+        recZ = recs.create({'tags': [(4, tagA.id), (4, tagB.id)]})
+        recs = recW + recX + recY + recZ
+
+        # test 'in'
+        result = recs.search([('tags', 'in', (tagA + tagB).ids)])
+        self.assertEqual(result, recX + recY + recZ)
+
+        result = recs.search([('tags', 'in', tagA.ids)])
+        self.assertEqual(result, recX + recZ)
+
+        result = recs.search([('tags', 'in', tagB.ids)])
+        self.assertEqual(result, recY + recZ)
+
+        result = recs.search([('tags', 'in', tagC.ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('tags', 'in', [])])
+        self.assertEqual(result, recs.browse())
+
+        # test 'not in'
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', (tagA + tagB).ids)])
+        self.assertEqual(result, recs - recX - recY - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagA.ids)])
+        self.assertEqual(result, recs - recX - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagB.ids)])
+        self.assertEqual(result, recs - recY - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagC.ids)])
+        self.assertEqual(result, recs)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', [])])
+        self.assertEqual(result, recs)
+
+        # special case: compare with False
+        result = recs.search([('id', 'in', recs.ids), ('tags', '=', False)])
+        self.assertEqual(result, recW)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', '!=', False)])
+        self.assertEqual(result, recs - recW)
+
+    def test_search_one2many(self):
+        """ Tests search on one2many fields. """
+        recs = self.env['test_new_api.multi']
+        recX = recs.create({'lines': [(0, 0, {}), (0, 0, {})]})
+        recY = recs.create({'lines': [(0, 0, {})]})
+        recZ = recs.create({})
+        recs = recX + recY + recZ
+        line1, line2, line3 = recs.mapped('lines')
+        line4 = recs.create({'lines': [(0, 0, {})]}).lines
+        line0 = line4.create({})
+
+        # test 'in'
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line2 + line3 + line4).ids)])
+        self.assertEqual(result, recX + recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line3 + line4).ids)])
+        self.assertEqual(result, recX + recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line4).ids)])
+        self.assertEqual(result, recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', line4.ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', [])])
+        self.assertEqual(result, recs.browse())
+
+        # test 'not in'
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line2 + line3).ids)])
+        self.assertEqual(result, recs - recX - recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line3).ids)])
+        self.assertEqual(result, recs - recX - recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line1.ids)])
+        self.assertEqual(result, recs - recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line4).ids)])
+        self.assertEqual(result, recs - recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line4.ids)])
+        self.assertEqual(result, recs)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', [])])
+        self.assertEqual(result, recs)
+
+        # these cases are weird
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line0).ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line0.ids)])
+        self.assertEqual(result, recs.browse())
+
+        # special case: compare with False
+        result = recs.search([('id', 'in', recs.ids), ('lines', '=', False)])
+        self.assertEqual(result, recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', '!=', False)])
+        self.assertEqual(result, recs - recZ)
+
+
 class TestHtmlField(common.TransactionCase):
 
     def setUp(self):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -448,6 +448,7 @@ def select_from_where(cr, select_field, from_table, where_field, where_ids, wher
     return res
 
 def select_distinct_from_where_not_null(cr, select_field, from_table):
+    # This method helper is deprecated, to remove in master
     cr.execute('SELECT distinct("%s") FROM "%s" where "%s" is not null' % (select_field, from_table, select_field))
     return [r[0] for r in cr.fetchall()]
 
@@ -975,19 +976,21 @@ class expression(object):
                     push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
 
                 else:
-                    # determine ids1 = records with lines
                     if comodel._fields[field.inverse_name].store and not (inverse_is_int and domain):
-                        ids1 = select_distinct_from_where_not_null(cr, field.inverse_name, comodel._table)
+                        # rewrite condition to match records with/without lines
+                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
+                        subquery = 'SELECT "%s" FROM "%s" where "%s" is not null' % (field.inverse_name, comodel._table, field.inverse_name)
+                        push(create_substitution_leaf(leaf, ('id', op1, (subquery, [])), internal=True))
                     else:
                         comodel_domain = [(field.inverse_name, '!=', False)]
                         if inverse_is_int and domain:
                             comodel_domain += domain
                         recs = comodel.search(comodel_domain).sudo().with_context(prefetch_fields=False)
+                        # determine ids1 = records with lines
                         ids1 = unwrap_inverse(recs.mapped(field.inverse_name))
-
-                    # rewrite condition to match records with/without lines
-                    op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
-                    push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
+                        # rewrite condition to match records with/without lines
+                        op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
+                        push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
 
             elif field.type == 'many2many':
                 rel_table, rel_id1, rel_id2 = field.relation, field.column1, field.column2
@@ -1026,12 +1029,10 @@ class expression(object):
                     push(create_substitution_leaf(leaf, ('id', subop, (subquery, [ids2])), internal=True))
 
                 else:
-                    # determine ids1 = records with relations
-                    ids1 = select_distinct_from_where_not_null(cr, rel_id1, rel_table)
-
                     # rewrite condition to match records with/without relations
-                    op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
-                    push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
+                    op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
+                    subquery = 'SELECT "%s" FROM "%s" where "%s" is not null' % (rel_id1, rel_table, rel_id1)
+                    push(create_substitution_leaf(leaf, ('id', op1, (subquery, [])), internal=True))
 
             elif field.type == 'many2one':
                 if operator in HIERARCHY_FUNCS:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Poorly performing queries like `('fk_column', '=', False)`

Current behavior before PR:

Query may consume all available RAM and run for a long time

Desired behavior after PR is merged:

Better queries 




--

