### PR TITLE
Story/10057

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -371,8 +371,8 @@ class QuantPackage(models.Model):
         'product.packaging', 'Package Type', index=True,
         help="This field should be completed only if everything inside the package share the same product, otherwise it doesn't really makes sense.")
     location_id = fields.Many2one(
-        'stock.location', 'Location', compute='_compute_package_info', search='_search_location',
-        index=True, readonly=True)
+        'stock.location', 'Location', compute='_compute_package_info', search=False,
+        index=True, readonly=True, store=True)
     company_id = fields.Many2one(
         'res.company', 'Company', compute='_compute_package_info', search='_search_company',
         index=True, readonly=True)
@@ -442,17 +442,6 @@ class QuantPackage(models.Model):
             else:
                 for ml in move_lines:
                     ml.qty_done = 0
-
-
-    def _search_location(self, operator, value):
-        if value:
-            packs = self.search([('quant_ids.location_id', operator, value)])
-        else:
-            packs = self.search([('quant_ids', operator, value)])
-        if packs:
-            return [('id', 'in', packs.ids)]
-        else:
-            return [('id', '=', False)]
 
     def _search_company(self, operator, value):
         if value:

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -370,6 +370,10 @@ class TestExpression(TransactionCase):
         partners = Partner.search([('child_ids.city', '=', 'foo')])
         self.assertFalse(partners)
 
+        # Test aliasing in subquery does not result in invalid query.
+        partners = self.env['res.users'].search([('partner_id.child_ids', '=', False)]).mapped('partner_id')
+        self.assertEqual(len(partners), 3)
+
     def test_15_equivalent_one2many_1(self):
         Company = self.env['res.company']
         company3 = Company.create({'name': 'Acme 3'})
@@ -481,7 +485,7 @@ class TestExpression(TransactionCase):
         # Test2: inheritance + relational fields
         users = Users.search([('child_ids.name', 'like', 'test_B')])
         self.assertEqual(users, b1, 'searching through inheritance failed')
-        
+
         # Special =? operator mean "is equal if right is set, otherwise always True"
         users = Users.search([('name', 'like', 'test'), ('parent_id', '=?', False)])
         self.assertEqual(users, a + b1 + b2, '(x =? False) failed')
@@ -731,7 +735,7 @@ class TestAutoJoin(TransactionCase):
         expected = "%s like %s" % (unaccent('"res_partner__bank_ids"."sanitized_acc_number"::text'), unaccent('%s'))
         self.assertIn(expected, sql_query[1],
             "_auto_join on: ('bank_ids.sanitized_acc_number', 'like', '..') query incorrect where condition")
-        
+
         self.assertIn('"res_partner"."id"="res_partner__bank_ids"."partner_id"', sql_query[1],
             "_auto_join on: ('bank_ids.sanitized_acc_number', 'like', '..') query incorrect join condition")
         self.assertIn('%' + name_test + '%', sql_query[2],
@@ -848,7 +852,7 @@ class TestAutoJoin(TransactionCase):
         expected = "%s like %s" % (unaccent('"res_country_state__country_id"."code"::text'), unaccent('%s'))
         self.assertIn(expected, sql_query[1],
             "_auto_join on for country_id: ('state_id.country_id.code', 'like', '..') query 1 incorrect where condition")
-        
+
         self.assertIn('"res_country_state"."country_id"="res_country_state__country_id"."id"', sql_query[1],
             "_auto_join on for country_id: ('state_id.country_id.code', 'like', '..') query 1 incorrect join condition")
         self.assertEqual(['%' + name_test + '%'], sql_query[2],
@@ -882,7 +886,7 @@ class TestAutoJoin(TransactionCase):
         expected = "%s like %s" % (unaccent('"res_partner__state_id__country_id"."code"::text'), unaccent('%s'))
         self.assertIn(expected, sql_query[1],
             "_auto_join on: ('state_id.country_id.code', 'like', '..') query incorrect where condition")
-        
+
         self.assertIn('"res_partner"."state_id"="res_partner__state_id"."id"', sql_query[1],
             "_auto_join on: ('state_id.country_id.code', 'like', '..') query incorrect join condition")
         self.assertIn('"res_partner__state_id"."country_id"="res_partner__state_id__country_id"."id"', sql_query[1],

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -918,6 +918,120 @@ class TestX2many(common.TransactionCase):
         self.assertEqual(result, recs - recZ)
 
 
+class TestX2many(common.TransactionCase):
+    def test_search_many2many(self):
+        """ Tests search on many2many fields. """
+        tags = self.env['test_new_api.multi.tag']
+        tagA = tags.create({})
+        tagB = tags.create({})
+        tagC = tags.create({})
+        recs = self.env['test_new_api.multi.line']
+        recW = recs.create({})
+        recX = recs.create({'tags': [(4, tagA.id)]})
+        recY = recs.create({'tags': [(4, tagB.id)]})
+        recZ = recs.create({'tags': [(4, tagA.id), (4, tagB.id)]})
+        recs = recW + recX + recY + recZ
+
+        # test 'in'
+        result = recs.search([('tags', 'in', (tagA + tagB).ids)])
+        self.assertEqual(result, recX + recY + recZ)
+
+        result = recs.search([('tags', 'in', tagA.ids)])
+        self.assertEqual(result, recX + recZ)
+
+        result = recs.search([('tags', 'in', tagB.ids)])
+        self.assertEqual(result, recY + recZ)
+
+        result = recs.search([('tags', 'in', tagC.ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('tags', 'in', [])])
+        self.assertEqual(result, recs.browse())
+
+        # test 'not in'
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', (tagA + tagB).ids)])
+        self.assertEqual(result, recs - recX - recY - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagA.ids)])
+        self.assertEqual(result, recs - recX - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagB.ids)])
+        self.assertEqual(result, recs - recY - recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', tagC.ids)])
+        self.assertEqual(result, recs)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', 'not in', [])])
+        self.assertEqual(result, recs)
+
+        # special case: compare with False
+        result = recs.search([('id', 'in', recs.ids), ('tags', '=', False)])
+        self.assertEqual(result, recW)
+
+        result = recs.search([('id', 'in', recs.ids), ('tags', '!=', False)])
+        self.assertEqual(result, recs - recW)
+
+    def test_search_one2many(self):
+        """ Tests search on one2many fields. """
+        recs = self.env['test_new_api.multi']
+        recX = recs.create({'lines': [(0, 0, {}), (0, 0, {})]})
+        recY = recs.create({'lines': [(0, 0, {})]})
+        recZ = recs.create({})
+        recs = recX + recY + recZ
+        line1, line2, line3 = recs.mapped('lines')
+        line4 = recs.create({'lines': [(0, 0, {})]}).lines
+        line0 = line4.create({})
+
+        # test 'in'
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line2 + line3 + line4).ids)])
+        self.assertEqual(result, recX + recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line3 + line4).ids)])
+        self.assertEqual(result, recX + recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', (line1 + line4).ids)])
+        self.assertEqual(result, recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', line4.ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'in', [])])
+        self.assertEqual(result, recs.browse())
+
+        # test 'not in'
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line2 + line3).ids)])
+        self.assertEqual(result, recs - recX - recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line3).ids)])
+        self.assertEqual(result, recs - recX - recY)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line1.ids)])
+        self.assertEqual(result, recs - recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line4).ids)])
+        self.assertEqual(result, recs - recX)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line4.ids)])
+        self.assertEqual(result, recs)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', [])])
+        self.assertEqual(result, recs)
+
+        # these cases are weird
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', (line1 + line0).ids)])
+        self.assertEqual(result, recs.browse())
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', 'not in', line0.ids)])
+        self.assertEqual(result, recs.browse())
+
+        # special case: compare with False
+        result = recs.search([('id', 'in', recs.ids), ('lines', '=', False)])
+        self.assertEqual(result, recZ)
+
+        result = recs.search([('id', 'in', recs.ids), ('lines', '!=', False)])
+        self.assertEqual(result, recs - recZ)
+
+
 class TestHtmlField(common.TransactionCase):
 
     def setUp(self):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -448,6 +448,7 @@ def select_from_where(cr, select_field, from_table, where_field, where_ids, wher
     return res
 
 def select_distinct_from_where_not_null(cr, select_field, from_table):
+    # This method helper is deprecated, to remove in master
     cr.execute('SELECT distinct("%s") FROM "%s" where "%s" is not null' % (select_field, from_table, select_field))
     return [r[0] for r in cr.fetchall()]
 
@@ -975,19 +976,21 @@ class expression(object):
                     push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
 
                 else:
-                    # determine ids1 = records with lines
                     if comodel._fields[field.inverse_name].store and not (inverse_is_int and domain):
-                        ids1 = select_distinct_from_where_not_null(cr, field.inverse_name, comodel._table)
+                        # rewrite condition to match records with/without lines
+                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
+                        subquery = 'SELECT "%s" FROM "%s" where "%s" is not null' % (field.inverse_name, comodel._table, field.inverse_name)
+                        push(create_substitution_leaf(leaf, ('id', op1, (subquery, [])), internal=True))
                     else:
                         comodel_domain = [(field.inverse_name, '!=', False)]
                         if inverse_is_int and domain:
                             comodel_domain += domain
                         recs = comodel.search(comodel_domain).sudo().with_context(prefetch_fields=False)
+                        # determine ids1 = records with lines
                         ids1 = unwrap_inverse(recs.mapped(field.inverse_name))
-
-                    # rewrite condition to match records with/without lines
-                    op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
-                    push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
+                        # rewrite condition to match records with/without lines
+                        op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
+                        push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
 
             elif field.type == 'many2many':
                 rel_table, rel_id1, rel_id2 = field.relation, field.column1, field.column2
@@ -1026,12 +1029,10 @@ class expression(object):
                     push(create_substitution_leaf(leaf, ('id', subop, (subquery, [ids2])), internal=True))
 
                 else:
-                    # determine ids1 = records with relations
-                    ids1 = select_distinct_from_where_not_null(cr, rel_id1, rel_table)
-
                     # rewrite condition to match records with/without relations
-                    op1 = 'in' if operator in NEGATIVE_TERM_OPERATORS else 'not in'
-                    push(create_substitution_leaf(leaf, ('id', op1, ids1), model))
+                    op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
+                    subquery = 'SELECT "%s" FROM "%s" where "%s" is not null' % (rel_id1, rel_table, rel_id1)
+                    push(create_substitution_leaf(leaf, ('id', op1, (subquery, [])), internal=True))
 
             elif field.type == 'many2one':
                 if operator in HIERARCHY_FUNCS:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Odoo may generate inefficient queries when dealing with large datasets and querying
one2many fields like this:

`('fk_column', '=', False)`

Current behavior before PR:
1. Fetches the complement of the ids required, 
2. Then uses fetched ids to build an `IN` clause which may contain > 1M records
3. Postgres may consume all available RAM while executing the query

Desired behavior after PR is merged:
1. Single query
2. No hardcoding of ids in IN clause
3. Acceptable query performance 




--

