### PR TITLE
[REF] odoo: Use simple ordering for searches in modified()

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4900,7 +4900,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     target0 = self
                 else:
                     env = self.env(user=SUPERUSER_ID, context={'active_test': False})
-                    target0 = env[model_name].search([(path, 'in', self.ids)])
+                    target0 = env[model_name].search([(path, 'in', self.ids)], order='id')
                     target0 = target0.with_env(self.env)
                 # prepare recomputation for each field on linked records
                 for field in stored:

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -752,13 +752,13 @@ class expression(object):
                         doms.insert(0, OR_OPERATOR)
                     doms += [AND_OPERATOR, ('parent_left', '<', rec.parent_right), ('parent_left', '>=', rec.parent_left)]
                 if prefix:
-                    return [(left, 'in', left_model.search(doms).ids)]
+                    return [(left, 'in', left_model.search(doms, order='id').ids)]
                 return doms
             else:
                 parent_name = parent or left_model._parent_name
                 child_ids = set(ids)
                 while ids:
-                    ids = left_model.search([(parent_name, 'in', ids)]).ids
+                    ids = left_model.search([(parent_name, 'in', ids)], order='id').ids
                     child_ids.update(ids)
                 return [(left, 'in', list(child_ids))]
 
@@ -773,7 +773,7 @@ class expression(object):
                         doms.insert(0, OR_OPERATOR)
                     doms += [AND_OPERATOR, ('parent_right', '>', rec.parent_left), ('parent_left', '<=',  rec.parent_left)]
                 if prefix:
-                    return [(left, 'in', left_model.search(doms).ids)]
+                    return [(left, 'in', left_model.search(doms, order='id').ids)]
                 return doms
             else:
                 parent_name = parent or left_model._parent_name
@@ -896,13 +896,13 @@ class expression(object):
                 raise NotImplementedError('auto_join attribute not supported on field %s' % field)
 
             elif len(path) > 1 and field.store and field.type == 'many2one':
-                right_ids = comodel.with_context(active_test=False).search([('.'.join(path[1:]), operator, right)]).ids
+                right_ids = comodel.with_context(active_test=False).search([('.'.join(path[1:]), operator, right)], order='id').ids
                 leaf.leaf = (path[0], 'in', right_ids)
                 push(leaf)
 
             # Making search easier when there is a left operand as one2many or many2many
             elif len(path) > 1 and field.store and field.type in ('many2many', 'one2many'):
-                right_ids = comodel.search([('.'.join(path[1:]), operator, right)]).ids
+                right_ids = comodel.search([('.'.join(path[1:]), operator, right)], order='id').ids
                 leaf.leaf = (path[0], 'in', right_ids)
                 push(leaf)
 
@@ -918,7 +918,7 @@ class expression(object):
                 else:
                     # Let the field generate a domain.
                     if len(path) > 1:
-                        right = comodel.search([('.'.join(path[1:]), operator, right)]).ids
+                        right = comodel.search([('.'.join(path[1:]), operator, right)], order='id').ids
                         operator = 'in'
                     domain = field.determine_domain(model, operator, right)
 
@@ -961,7 +961,7 @@ class expression(object):
                     else:
                         ids2 = [right]
                     if ids2 and inverse_is_int and domain:
-                        ids2 = comodel.search([('id', 'in', ids2)] + domain).ids
+                        ids2 = comodel.search([('id', 'in', ids2)] + domain, order='id').ids
 
                     # determine ids1 in model related to ids2
                     if not ids2:
@@ -991,7 +991,7 @@ class expression(object):
                         comodel_domain = [(field.inverse_name, '!=', False)]
                         if inverse_is_int and domain:
                             comodel_domain += domain
-                        recs = comodel.search(comodel_domain).sudo().with_context(prefetch_fields=False)
+                        recs = comodel.search(comodel_domain, order='id').sudo().with_context(prefetch_fields=False)
                         # determine ids1 = records with lines
                         ids1 = unwrap_inverse(recs.mapped(field.inverse_name))
                         # rewrite condition to match records with/without lines
@@ -1005,7 +1005,7 @@ class expression(object):
                     # determine ids2 in comodel
                     ids2 = to_ids(right, comodel)
                     domain = HIERARCHY_FUNCS[operator]('id', ids2, comodel)
-                    ids2 = comodel.search(domain).ids
+                    ids2 = comodel.search(domain, order='id').ids
 
                     # rewrite condition in terms of ids2
                     if comodel == model:


### PR DESCRIPTION
When searching for records with fields in need of recomputation, the order
of results does not matter. Explicitly specify an order of "id" for the
search() in modified() to avoid complex orderings involving joins.

When searching with dotted domains, Odoo performs intermediate searches
where the order of results does not matter. Explicitly specify an order of
"id" for these intermediate searches in odoo/osv/expression.py
to avoid complex orderings involving joins.

This improves performance by up to 5% in write-heavy workloads.