### PR TITLE
[FIX] base: Python 3.8 compatibility

### DIFF
--- a/odoo/addons/base/ir/ir_qweb/qweb.py
+++ b/odoo/addons/base/ir/ir_qweb/qweb.py
@@ -107,6 +107,7 @@ class Contextifier(ast.NodeTransformer):
                 # handle that cross-version
                 kwonlyargs=[],
                 kw_defaults=[],
+                posonlyargs=[],
             ),
             body=Contextifier(self._safe_names + tuple(names)).visit(node.body)
         ), node)
@@ -552,7 +553,7 @@ class QWeb(object):
                 arg(arg='values', annotation=None),
                 arg(arg='options', annotation=None),
                 arg(arg='log', annotation=None),
-            ], defaults=[], vararg=None, kwarg=None, kwonlyargs=[], kw_defaults=[]),
+            ], defaults=[], vararg=None, kwarg=None, posonlyargs=[], kwonlyargs=[], kw_defaults=[]),
             body=body or [ast.Return()],
             decorator_list=[])
         if lineno is not None:

--- a/odoo/addons/base/res/res_config.py
+++ b/odoo/addons/base/res/res_config.py
@@ -543,7 +543,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         # other fields: execute method 'set_values'
         # Methods that start with `set_` are now deprecated
         for method in dir(self):
-            if method.startswith('set_') and method is not 'set_values':
+            if method.startswith('set_') and method != 'set_values':
                 _logger.warning(_('Methods that start with `set_` are deprecated. Override `set_values` instead (Method %s)') % method)
         self.set_values()
 


### PR DESCRIPTION
Completely untested, but here's a trivial backport of the Python 3.8 fix from upstream master.