### PR TITLE
[IMP] stock: Don't remove linkage to previous moves when moves are cancelled

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1293,7 +1293,7 @@ class StockMove(models.Model):
                 if all(state in ('done', 'cancel') for state in siblings_states):
                     move.move_dest_ids.write({'procure_method': 'make_to_stock'})
                     move.move_dest_ids.write({'move_orig_ids': [(3, move.id, 0)]})
-        self.write({'state': 'cancel', 'move_orig_ids': [(5, 0, 0)]})
+        self.write({'state': 'cancel'})
         return True
 
     def _prepare_extra_move_vals(self, qty):


### PR DESCRIPTION
Task: 10902
User-story: 10383

Signed-off-by: Sean Quah <sean.quah@unipart.io>
