### PR TITLE
[FIX] auth_signup: Credentials validity checked before resetting token

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -38,8 +38,8 @@ class ResUsers(models.Model):
         if token:
             # signup with a token: find the corresponding partner id
             partner = self.env['res.partner']._signup_retrieve_partner(token, check_validity=True, raise_exception=True)
-            # invalidate signup token
-            partner.write({'signup_token': False, 'signup_type': False, 'signup_expiration': False})
+            # invalidate signup token and check password validity
+            partner.with_context(password=values.get('password')).write({'signup_token': False, 'signup_type': False, 'signup_expiration': False})
 
             partner_user = partner.user_ids and partner.user_ids[0] or False
 


### PR DESCRIPTION
Allow the password strength and history to be checked prior to resetting the signup token. Otherwise users will be unable to change thier password if they've previously attempted to change it to a poor or previously used password.

Story/1380

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
