### PR TITLE
[FIX] stock: Only free reserved quantity from move lines

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -501,6 +501,8 @@ class StockMoveLine(models.Model):
             product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True
         )
         if quantity > available_quantity:
+            # Only free quantity reserved from move lines
+            quantity -= available_quantity
             # We now have to find the move lines that reserved our now unavailable quantity. We
             # take care to exclude ourselves and the move lines were work had already been done.
             oudated_move_lines_domain = [


### PR DESCRIPTION
Free reservation was unreserving the total adjusted quantity from
move lines instead of just the difference between new quantity and
quantity reserved.
For instance, having 100 units in a location and only 10 of them
reserved, when adjusting to quantity 8, it has to unreserve 2 units
instead of 92.
