### PR TITLE
[IMP] stock: Create new function to control move line reuse when reserving

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -926,8 +926,7 @@ class StockMove(models.Model):
 
         # Find a candidate move line to update or create a new one.
         for reserved_quant, quantity in quants:
-            to_update = self.move_line_ids.filtered(lambda m: m.product_id.tracking != 'serial' and
-                                                    m.location_id.id == reserved_quant.location_id.id and m.lot_id.id == reserved_quant.lot_id.id and m.package_id.id == reserved_quant.package_id.id and m.owner_id.id == reserved_quant.owner_id.id)
+            to_update = self.move_line_ids.filtered(lambda m: m._can_merge_quant_reservation(reserved_quant))
             if to_update:
                 to_update[0].with_context(bypass_reservation_update=True).product_uom_qty += self.product_id.uom_id._compute_quantity(quantity, to_update[0].product_uom_id, rounding_method='HALF-UP')
             else:

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -544,3 +544,18 @@ class StockMoveLine(models.Model):
                 if quantity == 0.0:
                     break
             move_to_recompute_state._recompute_state()
+
+    def _can_merge_quant_reservation(self, quant):
+        """ Returns True if the reserved quantity for the given quant can be merged into this move
+        line.
+        """
+        self.ensure_one()
+        quant.ensure_one()
+
+        return (
+            self.product_id.tracking != 'serial' and
+            self.location_id.id == quant.location_id.id and
+            self.lot_id.id == quant.lot_id.id and
+            self.package_id.id == quant.package_id.id and
+            self.owner_id.id == quant.owner_id.id
+        )


### PR DESCRIPTION
Move condition to find matching move lines in stock.move
_update_reserved_quantity() out into its own stock.move.line function called
_can_merge_quant_reservation() that can be easily overridden.

User-story: 11559

Signed-off-by: Sean Quah <sean.quah@unipart.io>
