### PR TITLE
Story/11940

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -917,7 +917,7 @@ class StockMove(models.Model):
 
         try:
             if not float_is_zero(taken_quantity, precision_rounding=self.product_id.uom_id.rounding):
-                quants = self.env['stock.quant']._update_reserved_quantity(
+                quants = self._update_quant_reserved_quantity(
                     self.product_id, location_id, taken_quantity, lot_id=lot_id,
                     package_id=package_id, owner_id=owner_id, strict=strict
                 )
@@ -936,6 +936,10 @@ class StockMove(models.Model):
                 else:
                     self.env['stock.move.line'].create(self._prepare_move_line_vals(quantity=quantity, reserved_quant=reserved_quant))
         return taken_quantity
+
+    def _update_quant_reserved_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, strict=False):
+        Quant = self.env['stock.quant']
+        return Quant._update_reserved_quantity(product_id, location_id, quantity, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
 
     def _action_assign(self):
         """ Reserve stock moves by creating their stock move lines. A stock move is

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -470,7 +470,7 @@ class StockMoveLine(models.Model):
     def _update_quant_available_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, in_date=None, just_update=False):
         Quant = self.env['stock.quant']
         return Quant._update_available_quantity(
-            product_id, location_id, quantity, lot_id=lot_id, package_id=package_id, owner_id=owner_id, just_update=just_update)
+            product_id, location_id, quantity, lot_id=lot_id, package_id=package_id, owner_id=owner_id, in_date=in_date, just_update=just_update)
 
     @api.model
     def _update_quant_reserved_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, strict=False):

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -165,7 +165,7 @@ class StockQuant(models.Model):
         return self.browse([x[0] for x in res])
 
     @api.model
-    def _get_available_quantity(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, allow_negative=False):
+    def _get_available_quantity(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, allow_negative=False, **kwargs):
         """ Return the available quantity, i.e. the sum of `quantity` minus the sum of
         `reserved_quantity`, for the set of quants sharing the combination of `product_id,
         location_id` if `strict` is set to False or sharing the *exact same characteristics*
@@ -184,7 +184,7 @@ class StockQuant(models.Model):
         :return: available quantity as a float
         """
         self = self.sudo()
-        quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
+        quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict, **kwargs)
         rounding = product_id.uom_id.rounding
         if product_id.tracking == 'none':
             available_quantity = sum(quants.mapped('quantity')) - sum(quants.mapped('reserved_quantity'))
@@ -273,7 +273,7 @@ class StockQuant(models.Model):
         if just_update:
             return True
 
-        return self._get_available_quantity(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True, allow_negative=True), fields.Datetime.from_string(in_date)
+        return self._get_available_quantity(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True, allow_negative=True, **kwargs), fields.Datetime.from_string(in_date)
 
     @api.model
     def _update_reserved_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, strict=False, **kwargs):
@@ -295,7 +295,7 @@ class StockQuant(models.Model):
 
         if float_compare(quantity, 0, precision_rounding=rounding) > 0:
             # if we want to reserve
-            available_quantity = self._get_available_quantity(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
+            available_quantity = self._get_available_quantity(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict, **kwargs)
             if float_compare(quantity, available_quantity, precision_rounding=rounding) > 0:
                 raise UserError(_('It is not possible to reserve more products of %s than you have in stock.') % product_id.display_name)
         elif float_compare(quantity, 0, precision_rounding=rounding) < 0:

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -276,7 +276,7 @@ class StockQuant(models.Model):
         return self._get_available_quantity(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True, allow_negative=True), fields.Datetime.from_string(in_date)
 
     @api.model
-    def _update_reserved_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, strict=False):
+    def _update_reserved_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, strict=False, **kwargs):
         """ Increase the reserved quantity, i.e. increase `reserved_quantity` for the set of quants
         sharing the combination of `product_id, location_id` if `strict` is set to False or sharing
         the *exact same characteristics* otherwise. Typically, this method is called when reserving
@@ -290,7 +290,7 @@ class StockQuant(models.Model):
         """
         self = self.sudo()
         rounding = product_id.uom_id.rounding
-        quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
+        quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict, **kwargs)
         reserved_quants = []
 
         if float_compare(quantity, 0, precision_rounding=rounding) > 0:

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -189,6 +189,24 @@ class StockQuant(TransactionCase):
         self.env = self.env(user=self.env.ref('base.user_demo'))
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product1, stock_location), 1.0)
 
+    def test_get_available_quantity_10(self):
+        """ Check accepts and forwards arbitrary keyword arguments.
+        """
+        Quant = self.env['stock.quant']
+        stock_location = self.env.ref('stock.stock_location_stock')
+        product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+        })
+        self.env['stock.quant'].create({
+            'product_id': product1.id,
+            'location_id': stock_location.id,
+            'quantity': 1.0,
+        })
+        with mock.patch.object(Quant.__class__, '_gather', autospec=True, wraps=True) as mock_gather:
+            Quant._get_available_quantity(product1, stock_location, a=1, b=2)
+        mock_gather.assert_called_once_with(Quant.browse(), product1, stock_location, lot_id=None, package_id=None, owner_id=None, strict=False, a=1, b=2)
+
     def test_increase_available_quantity_1(self):
         """ Increase the available quantity when no quants are already in a location.
         """
@@ -563,7 +581,7 @@ class StockQuant(TransactionCase):
             Quant._update_reserved_quantity(product1, stock_location, 10.0, a=1, b=2)
         mock_gather.assert_has_calls([
             mock.call(Quant.browse(), product1, stock_location, lot_id=None, package_id=None, owner_id=None, strict=False, a=1, b=2),
-            mock.call(Quant.browse(), product1, stock_location, lot_id=None, package_id=None, owner_id=None, strict=False)])
+            mock.call(Quant.browse(), product1, stock_location, lot_id=None, package_id=None, owner_id=None, strict=False, a=1, b=2)])
         self.assertEqual(Quant._get_available_quantity(product1, stock_location), 0.0)
         self.assertEqual(len(Quant._gather(product1, stock_location)), 1)
 


### PR DESCRIPTION
Allow passing arbitrary keyword arguments to `Quant._update_reserved_quantity`, similar to previous changes for `Quant._update_available_quantity`.

Extract calls to `Quant._update_reserved_quantity` into a separate method so that they can be overridden.
