### PR TITLE
[FIX] odoo: Prevent cache from holding on to old Environments

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -9,6 +9,7 @@ from functools import partial
 from operator import attrgetter
 import itertools
 import logging
+import weakref
 
 import pytz
 
@@ -757,7 +758,7 @@ class Field(MetaField('DummyField', (object,), {})):
         # IMPORTANT: odoo.api.Cache.get_records() depends on the fact that the
         # result does not depend on record.id. If you ever make the following
         # dependent on record.id, don't forget to fix the other method!
-        return env if self.context_dependent else (env.cr, env.uid)
+        return weakref.ref(env) if self.context_dependent else (env.cr, env.uid)
 
     def null(self, record):
         """ Return the null value for this field in the record format. """


### PR DESCRIPTION
When new Environments are being created, Odoo first checks its set of
existing Environments for a matching one to reuse. To avoid holding on to
stale Environments that are no longer in use, the set is a WeakSet.
If many environments get created within the same transaction and never get
garbage collected for whatever reason, the set keeps growing and the
creation of new Environments slows down.

One notable module that creates lots of Environments is base_automation,
which creates a new context and thus environment for every record written if
there is a write hook configured.

Since Environments are also used as non-weak keys in the Odoo cache,
Environments are almost always guaranteed to hang around forever, defeating
the purpose of the WeakSet. Changing the cache keys to wrap Environments in
a weak reference allows them to be garbage collected again and avoids
performance degradation in code that creates lots of Environments such as
base_automation.

User-story: 11957

Signed-off-by: Sean Quah <sean.quah@unipart.io>
