### PR TITLE
[ADD] unittests - output test results as XML

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -16,6 +16,7 @@ import odoo.modules.db
 import odoo.modules.graph
 import odoo.modules.migration
 import odoo.modules.registry
+from odoo.tools import config
 from .. import SUPERUSER_ID, api, tools
 from .module import adapt_version, initialize_sys_path, load_openerp_module
 
@@ -261,14 +262,20 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 env['ir.http']._clear_routing_map()     # force routing map to be rebuilt
 
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
-                report.update(test_results)
-                test_time = time.time() - tests_t0
-                test_queries = odoo.sql_db.sql_counter - tests_q0
+                if config['test_xml_file']:
+                    import xmlrunner
+                    xml_output_file_name = '.'.join([config['test_xml_file'], str(time.time()), 'xml'])
+                    _logger.info('saving xml results to %s', xml_output_file_name)
+                    xml_output_file = open(xml_output_file_name, 'wb')
+                    runner = xmlrunner.XMLTestRunner(output=xml_output_file)
+                    test_results = runner.run(suite)
+                    report.update(test_results)
+                    test_time = time.time() - tests_t0
+                    test_queries = odoo.sql_db.sql_counter - tests_q0
 
-                # tests may have reset the environment
-                env = api.Environment(cr, SUPERUSER_ID, {})
-                module = env['ir.module.module'].browse(module_id)
+                    # tests may have reset the environment
+                    env = api.Environment(cr, SUPERUSER_ID, {})
+                    module = env['ir.module.module'].browse(module_id)
 
         if needs_update:
             processed_modules.append(package.name)

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -133,11 +133,9 @@ def initialize_sys_path():
 
 def get_module_path(module, downloaded=False, display_warning=True):
     """Return the path of the given module.
-
     Search the addons paths and return the first path where the given
     module is found. If downloaded is True, return the default addons
     path if nothing else is found.
-
     """
     for adp in odoo.addons.__path__:
         files = [opj(adp, module, manifest) for manifest in MANIFEST_NAMES] +\
@@ -181,13 +179,10 @@ def get_module_filetree(module, dir='.'):
 
 def get_resource_path(module, *args):
     """Return the full path of a resource of the given module.
-
     :param module: module name
     :param list(str) args: resource path components within module
-
     :rtype: str
     :return: absolute path to the resource
-
     TODO make it available inside on osv object (self.get_resource_path)
     """
     mod_path = get_module_path(module)
@@ -205,15 +200,11 @@ get_module_resource = get_resource_path
 def get_resource_from_path(path):
     """Tries to extract the module name and the resource's relative path
     out of an absolute resource path.
-
     If operation is successfull, returns a tuple containing the module name, the relative path
     to the resource using '/' as filesystem seperator[1] and the same relative path using
     os.path.sep seperators.
-
     [1] same convention as the resource path declaration in manifests
-
     :param path: absolute resource path
-
     :rtype: tuple
     :return: tuple(module_name, relative_path, os_relative_path) if possible, else None
     """
@@ -250,21 +241,15 @@ def module_manifest(path):
 def get_module_root(path):
     """
     Get closest module's root beginning from path
-
         # Given:
         # /foo/bar/module_dir/static/src/...
-
         get_module_root('/foo/bar/module_dir/static/')
         # returns '/foo/bar/module_dir'
-
         get_module_root('/foo/bar/module_dir/')
         # returns '/foo/bar/module_dir'
-
         get_module_root('/foo/bar')
         # returns None
-
     @param path: Path from which the lookup should start
-
     @return:  Module root path or None if not found
     """
     while not module_manifest(path):
@@ -344,7 +329,6 @@ def load_information_from_description_file(module, mod_path=None):
 
 def load_openerp_module(module_name):
     """ Load an OpenERP module, if not already loaded.
-
     This loads the module and register all of its models, thanks to either
     the MetaModel metaclass, or the explicit instantiation of the model.
     This is also used to load server-wide module (i.e. it is also used

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -21,7 +21,6 @@ crypt_context = CryptContext(schemes=['pbkdf2_sha512', 'plaintext'],
 
 class MyOption (optparse.Option, object):
     """ optparse Option with two additional attributes.
-
     The list of command line options (getopt.Option) is used to create the
     list of the configuration file options. When reading the file, and then
     reading the command line arguments, we don't want optparse.parse results
@@ -30,7 +29,6 @@ class MyOption (optparse.Option, object):
     were really provided by the user or not. A solution is to not use
     optparse's default attribute, but use a custom one (that will be copied
     to create the default values of the configuration file).
-
     """
     def __init__(self, *opts, **attrs):
         self.my_default = attrs.pop('my_default', None)
@@ -65,7 +63,6 @@ def _deduplicate_loggers(loggers):
 class configmanager(object):
     def __init__(self, fname=None):
         """Constructor.
-
         :param fname: a shortcut allowing to instantiate :class:`configmanager`
                       from Python code without resorting to environment
                       variable
@@ -171,6 +168,8 @@ class configmanager(object):
                          The module, class, and method will respectively match the module name, test class name and test method name.
                          examples: :TestClass.test_func,/test_module,external
                          """)
+        group.add_option("--test-xml-file", dest="test_xml_file", my_default=False,
+                         help="Save the unittest results to a XML file.")
 
         group.add_option("--screencasts", dest="screencasts", action="store", my_default=None,
                          metavar='DIR',
@@ -339,16 +338,12 @@ class configmanager(object):
     def parse_config(self, args=None):
         """ Parse the configuration file (if any) and the command-line
         arguments.
-
         This method initializes odoo.tools.config and openerp.conf (the
         former should be removed in the future) with library-wide
         configuration values.
-
         This method must be called before proper usage of this library can be
         made.
-
         Typical usage of this method:
-
             odoo.tools.config.parse_config(sys.argv[1:])
         """
         opt = self._parse_config(args)
@@ -455,7 +450,7 @@ class configmanager(object):
             'dev_mode', 'shell_interface', 'smtp_ssl', 'load_language',
             'stop_after_init', 'without_demo', 'http_enable', 'syslog',
             'list_db', 'proxy_mode',
-            'test_file', 'test_tags',
+            'test_file', 'test_tags', 'test_xml_file',
             'osv_memory_count_limit', 'osv_memory_age_limit', 'transient_age_limit', 'max_cron_threads', 'unaccent',
             'data_dir',
             'server_wide_modules',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Add configuration to enable unittest results to be saved to XML file.

Current behavior before PR: unittest results not currently being saved to XML file.

Desired behavior after PR is merged: unittest results are saved to XML file.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
