### PR TITLE
[ADD] odoo - unitest - output test results as XML

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -16,6 +16,7 @@ import odoo.modules.db
 import odoo.modules.graph
 import odoo.modules.migration
 import odoo.modules.registry
+from odoo.tools import config
 from .. import SUPERUSER_ID, api, tools
 from .module import adapt_version, initialize_sys_path, load_openerp_module
 
@@ -261,7 +262,16 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 env['ir.http']._clear_routing_map()     # force routing map to be rebuilt
 
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
+                if config.get('test_xml_file'):
+                    import xmlrunner
+                    xml_output_file_name = '.'.join([config['test_xml_file'], str(time.time()), 'xml'])
+                    _logger.info('saving xml results to %s', xml_output_file_name)
+                    xml_output_file = open(xml_output_file_name, 'wb')
+                    runner = xmlrunner.XMLTestRunner(output=xml_output_file)
+                    test_results = runner.run(suite)
+                else:
+                    test_results = loader.run_suite(suite, module_name)
+
                 report.update(test_results)
                 test_time = time.time() - tests_t0
                 test_queries = odoo.sql_db.sql_counter - tests_q0

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -171,6 +171,8 @@ class configmanager(object):
                          The module, class, and method will respectively match the module name, test class name and test method name.
                          examples: :TestClass.test_func,/test_module,external
                          """)
+        group.add_option("--test-xml-file", dest="test_xml_file", my_default=False,
+                         help="Save the unittest results to a XML file.")
 
         group.add_option("--screencasts", dest="screencasts", action="store", my_default=None,
                          metavar='DIR',
@@ -455,7 +457,7 @@ class configmanager(object):
             'dev_mode', 'shell_interface', 'smtp_ssl', 'load_language',
             'stop_after_init', 'without_demo', 'http_enable', 'syslog',
             'list_db', 'proxy_mode',
-            'test_file', 'test_tags',
+            'test_file', 'test_tags', 'test_xml_file',
             'osv_memory_count_limit', 'osv_memory_age_limit', 'transient_age_limit', 'max_cron_threads', 'unaccent',
             'data_dir',
             'server_wide_modules',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: XML output of unit tests

Current behavior before PR: No output of unit test results

Desired behavior after PR is merged: unit tests will have XML outputs




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
