### PR TITLE
[ADD] stock: Hook to _unreserve_initial_demand

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1473,6 +1473,11 @@ class StockMove(models.Model):
                         break
         return extra_move | self
 
+    def _unreserve_initial_demand(self, new_move):
+        """Dummy function called during _action_done() - intended as a hook
+        """
+        pass
+
     def _action_done(self, cancel_backorder=False):
         self.filtered(lambda move: move.state == 'draft')._action_confirm()  # MRP allows scrapping draft moves
         moves = self.exists().filtered(lambda x: x.state not in ('done', 'cancel'))
@@ -1494,7 +1499,7 @@ class StockMove(models.Model):
 
         moves_todo._check_company()
         # Split moves where necessary and move quants
-        backorder_moves_vals = []
+        backorder_moves = self.browse()
         for move in moves_todo:
             # To know whether we need to create a backorder or not, round to the general product's
             # decimal precision and not the product's UOM.
@@ -1503,8 +1508,9 @@ class StockMove(models.Model):
                 # Need to do some kind of conversion here
                 qty_split = move.product_uom._compute_quantity(move.product_uom_qty - move.quantity_done, move.product_id.uom_id, rounding_method='HALF-UP')
                 new_move_vals = move._split(qty_split)
-                backorder_moves_vals += new_move_vals
-        backorder_moves = self.env['stock.move'].create(backorder_moves_vals)
+                backorder_move = self.create(new_move_vals)
+                move._unreserve_initial_demand(backorder_move)
+                backorder_moves |= backorder_move
         backorder_moves._action_confirm(merge=False)
         if cancel_backorder:
             backorder_moves.with_context(moves_todo=moves_todo)._action_cancel()


### PR DESCRIPTION
To add this hook, we have to revert to creating backorder_moves
individually rather than all at once, to preserve the link between move
and backorder_move (there doesn't appear to be any other way to determine
which move should be linked to which)

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 420

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
