### PR TITLE
[FIX] odoo: Disable name translation

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -161,7 +161,7 @@ class Route(models.Model):
     _description = "Inventory Routes"
     _order = 'sequence'
 
-    name = fields.Char('Route Name', required=True, translate=True)
+    name = fields.Char('Route Name', required=True)
     active = fields.Boolean('Active', default=True, help="If the active field is set to False, it will allow you to hide the route without removing it.")
     sequence = fields.Integer('Sequence', default=0)
     pull_ids = fields.One2many('procurement.rule', 'route_id', 'Procurement Rules', copy=True, 

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -19,7 +19,7 @@ class PickingType(models.Model):
     _description = "The operation type determines the picking view"
     _order = 'sequence, id'
 
-    name = fields.Char('Operation Types Name', required=True, translate=True)
+    name = fields.Char('Operation Types Name', required=True)
     color = fields.Integer('Color')
     sequence = fields.Integer('Sequence', help="Used to order the 'All Operations' kanban view")
     sequence_id = fields.Many2one('ir.sequence', 'Reference Sequence', required=True)


### PR DESCRIPTION
Disable name translation for picking types and routes,
this avoids complications when duplicating, where the
new duplicated name was not being saved and was being
treated as a translation.

User-story: 621

Signed-off-by: Caleb Shelton <cshelton@unipart.io>