### PR TITLE
[IMP] odoo: Report skipped unit tests,

### DIFF
--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -20,7 +20,7 @@ class OdooTestResult(unittest.result.TestResult):
         self.queries_start = None
 
     def __str__(self):
-        return f'{len(self.failures)} failed, {len(self.errors)} error(s) of {self.testsRun} tests'
+        return f'{len(self.failures)} failed, {len(self.errors)} error(s), {len(self.skipped)} skipped of {self.testsRun} tests'
 
     def update(self, other):
         """ Merges an other test result into this one, only updates contents


### PR DESCRIPTION
story/460

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

Odoo only reports errors and failures in its summary of unit tests
results.  This may give the misleading impression that any skipped tests
have passed, when in fact they have been skipped.

This change adds the number of skipped tests to the summary line.


