### PR TITLE
[ADD] base: Mechanism for adding grouping criteria to global record r…

### DIFF
--- a/odoo/addons/base/views/ir_rule_views.xml
+++ b/odoo/addons/base/views/ir_rule_views.xml
@@ -23,6 +23,7 @@
                     <field name="domain_force" colspan="2" nolabel="1"/>
                     <group string="Groups (no group = global)">
                         <field name="global"/>
+                        <field name="global_grouping_criteria" attrs="{'invisible': [('global', '=', False)]}"/>
                         <field name="groups" nolabel="1" colspan="4"/>
                     </group>
                     <i class="fa fa-info fa-3x text-info float-left" role="img" aria-label="Info" title="Info"/>
@@ -36,7 +37,8 @@
                       <p>
                         Detailed algorithm:
                         <ol>
-                          <li>Global rules are combined together with a logical AND operator, and with the result of the following steps</li>
+                          <li>Global rules are combined together with a logical AND operator (unless Global Rule Grouping Criteria matches - then OR),</li>
+                          <li>and with the result of the following steps</li>
                           <li>Group-specific rules are combined together with a logical OR operator</li>
                           <li>If user belongs to several groups, the results from step 2 are combined with logical OR operator</li>
                         </ol>


### PR DESCRIPTION
…ules

- If the mechanism is not used, the system will behave as it used to.
- If a grouping criteria is set, then if multiple rules are found
    with the same grouping criteria, then their domains will be
    OR'd together, instead of AND'ed.

    The global and group rules will still be AND'ed together, and
    the group rules will still be OR'd together.

This allows for multiple overlapping global record rules to be in place
on a single model and for their domains to cross-over

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 957_picking_type_access

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
