### PR TITLE
story #1669 UDES 14 - Potential error when confirming a picking due to email config

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1835,7 +1835,7 @@ class MailThread(models.AbstractModel):
             raise ValueError('message_post partner_ids and channel_ids must be integer list, not commands')
 
         # Find the message's author
-        author_id, email_from = self._message_compute_author(author_id, email_from, raise_exception=True)
+        author_id, email_from = self._message_compute_author(author_id, email_from, raise_exception=False)
 
         if subtype_xmlid:
             subtype_id = self.env['ir.model.data'].xmlid_to_res_id(subtype_xmlid)


### PR DESCRIPTION
[IMP] mail: Change the raise exception flag, such that if a user doesn't have an email set on their partner record, no exception is raised when confirming a picking.

Story/1669

Signed off by: Jack Birch <jack.birch@unipart.io>
