### PR TITLE
Story/2466 - Move delete action to the end of the actions list

### DIFF
--- a/addons/web/static/src/js/components/action_menus.js
+++ b/addons/web/static/src/js/components/action_menus.js
@@ -85,7 +85,12 @@ odoo.define('web.ActionMenus', function (require) {
                 }
             }
 
-            return [...callbackActions, ...formattedActions, ...registryActions];
+            // UDES change: Additional callback based options to show at the bottom of the list
+            const callbackActionsLast = (props.items.otherLast || []).map(
+                action => Object.assign({ key: `action-${action.description}` }, action)
+            );
+
+            return [...callbackActions, ...formattedActions, ...registryActions, ...callbackActionsLast];
         }
 
         /**
@@ -188,6 +193,7 @@ odoo.define('web.ActionMenus', function (require) {
                 action: { type: Array, optional: 1 },
                 print: { type: Array, optional: 1 },
                 other: { type: Array, optional: 1 },
+                otherLast: { type: Array, optional: 1 }, // UDES change: callback options to be shown at the end
             },
         },
     };

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -196,6 +196,8 @@ var FormController = BasicController.extend({
         const props = this._super(...arguments);
         const activeField = this.model.getActiveField(state);
         const otherActionItems = [];
+        // UDES change: Actions to be shown at the end of the list
+        const otherActionItemsLast = [];
         if (this.archiveEnabled && activeField in state.data) {
             if (state.data[activeField]) {
                 otherActionItems.push({
@@ -220,13 +222,13 @@ var FormController = BasicController.extend({
             });
         }
         if (this.activeActions.delete) {
-            otherActionItems.push({
+            otherActionItemsLast.push({
                 description: _t("Delete"),
                 callback: () => this._onDeleteRecord(this),
             });
         }
         return Object.assign(props, {
-            items: Object.assign(this.toolbarActions, { other: otherActionItems }),
+            items: Object.assign(this.toolbarActions, { other: otherActionItems, otherLast: otherActionItemsLast }),
         });
     },
     /**

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -436,6 +436,8 @@ var ListController = BasicController.extend({
         }
         const props = this._super(...arguments);
         const otherActionItems = [];
+        // UDES change: Actions to be shown at the end of the list
+        const otherActionItemsLast = [];
         if (this.isExportEnable) {
             otherActionItems.push({
                 description: _t("Export"),
@@ -456,13 +458,13 @@ var ListController = BasicController.extend({
             });
         }
         if (this.activeActions.delete) {
-            otherActionItems.push({
+            otherActionItemsLast.push({
                 description: _t("Delete"),
                 callback: () => this._onDeleteSelectedRecords()
             });
         }
         return Object.assign(props, {
-            items: Object.assign({}, this.toolbarActions, { other: otherActionItems }),
+            items: Object.assign({}, this.toolbarActions, { other: otherActionItems, otherLast: otherActionItemsLast }),
             context: state.getContext(),
             domain: state.getDomain(),
             isDomainSelected: this.isDomainSelected,


### PR DESCRIPTION
Has been decided that having the delete button right under duplicate is likely to cause a potential problem, so it has been moved to the very bottom of the list.