### PR TITLE
[FIX] odoo: Stop resetting priorities on pickings

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -781,7 +781,7 @@ class Picking(models.Model):
                 picking.move_lines.write({'restrict_partner_id': picking.owner_id.id})
                 picking.move_line_ids.write({'owner_id': picking.owner_id.id})
         todo_moves._action_done(cancel_backorder=self.env.context.get('cancel_backorder'))
-        self.write({'date_done': fields.Datetime.now(), 'priority': '0'})
+        self.write({'date_done': fields.Datetime.now()})
 
         # if incoming moves make other confirmed/partially_available moves available, assign them
         done_incoming_moves = self.filtered(lambda p: p.picking_type_id.code == 'incoming').move_lines.filtered(lambda m: m.state == 'done')


### PR DESCRIPTION
Stop done/cancelled pickings having their priorities set to "Normal"

User-story: 2433

Signed-off-by: Caleb Shelton <caleb.shelton@unipart.io>
