### PR TITLE
story #3663 eCommerce: Portal is only visible to authenticated users

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1193,7 +1193,7 @@ class GroupsView(models.Model):
                     user_type_field_name = field_name
                     user_type_readonly = str({'readonly': [(user_type_field_name, '!=', group_employee.id)]})
                     attrs['widget'] = 'radio'
-                    attrs['groups'] = 'base.group_no_one'
+                    attrs['groups'] = self._authorisation_for_user_type_fields()
                     xml1.append(E.field(name=field_name, **attrs))
                     xml1.append(E.newline())
 
@@ -1243,6 +1243,13 @@ class GroupsView(models.Model):
             new_context.pop('install_filename', None)  # don't set arch_fs for this computed view
             new_context['lang'] = None
             view.with_context(new_context).write({'arch': xml_content})
+    
+    def _authorisation_for_user_type_fields(self):
+        """
+        Group that can view the user type. This has been put in a
+        method so it can overridden.
+        """
+        return "base.group_no_one"
 
     def get_application_groups(self, domain):
         """ Return the non-share groups that satisfy ``domain``. """


### PR DESCRIPTION
- Make the security group property on the "user types" field extendable so it can be overwritten in other modules
