### PR TITLE
Port odoo to Python 3.1x/Werkzeug 2.x, backward …

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1104,10 +1104,10 @@ class Proxy(http.Controller):
             if not data:
                 raise werkzeug.exceptions.BadRequest()
             from werkzeug.test import Client
-            from werkzeug.wrappers import BaseResponse
+            from werkzeug.wrappers import Response
             base_url = request.httprequest.base_url
             query_string = request.httprequest.query_string
-            client = Client(http.root, BaseResponse)
+            client = Client(http.root, Response)
             headers = {'X-Openerp-Session-Id': request.session.sid}
             return client.post('/' + path, base_url=base_url, query_string=query_string,
                                headers=headers, data=data)

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -69,7 +69,7 @@ class ModelsConverter(werkzeug.routing.BaseConverter):
         return ",".join(value.ids)
 
 
-class SignedIntConverter(werkzeug.routing.NumberConverter):
+class SignedIntConverter(werkzeug.routing.IntegerConverter):
     regex = r'-?\d+'
     num_convert = int
 

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -310,7 +310,11 @@ class QWeb(object):
         try:
             # noinspection PyBroadException
             ns = {}
-            unsafe_eval(compile(astmod, '<template>', 'exec'), ns)
+            # Python 3.11 validates ast.AST nodes on compile(), so unparse them
+            if hasattr(ast, 'unparse'):
+                unsafe_eval(compile(ast.unparse(astmod), '<template>', 'exec'), ns)
+            else:   # Python 3.7
+                unsafe_eval(compile(astmod, '<template>', 'exec'), ns)
             compiled = ns[def_name]
         except QWebException as e:
             raise e

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -538,7 +538,7 @@ def route(route=None, **kw):
 
             if isinstance(response, werkzeug.exceptions.HTTPException):
                 response = response.get_response(request.httprequest.environ)
-            if isinstance(response, werkzeug.wrappers.BaseResponse):
+            if isinstance(response, werkzeug.wrappers.Response):
                 response = Response.force_type(response)
                 response.set_default()
                 return response

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6376,9 +6376,9 @@ Fields:
         return self.concat(*records_batches)
 
 
-collections.Set.register(BaseModel)
+collections.abc.Set.register(BaseModel)
 # not exactly true as BaseModel doesn't have __reversed__, index or count
-collections.Sequence.register(BaseModel)
+collections.abc.Sequence.register(BaseModel)
 
 class RecordCache(MutableMapping):
     """ A mapping from field names to values, to read and update the cache of a record. """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2343,7 +2343,7 @@ class O2MProxy(X2MProxy):
         del self._records[index]
         self._parent._perform_onchange([self._field])
 
-class M2MProxy(X2MProxy, collections.Sequence):
+class M2MProxy(X2MProxy, collections.abc.Sequence):
     """ M2MProxy()
 
     Behaves as a :class:`~collection.Sequence` of recordsets, can be

--- a/odoo/tools/_vendor/sessions.py
+++ b/odoo/tools/_vendor/sessions.py
@@ -26,7 +26,6 @@ from pickle import load
 from time import time
 
 from werkzeug.datastructures import CallbackDict
-from werkzeug.posixemulation import rename
 
 _sha1_re = re.compile(r"^[a-f0-9]{40}$")
 
@@ -198,7 +197,7 @@ class FilesystemSessionStore(SessionStore):
         finally:
             f.close()
         try:
-            rename(tmp, fn)
+            os.rename(tmp, fn)
             os.chmod(fn, self.mode)
         except (IOError, OSError):
             pass

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -415,7 +415,7 @@ dateutil = wrap_module(dateutil, {
     for mod in mods
 })
 json = wrap_module(__import__('json'), ['loads', 'dumps'])
-time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime'])
+time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime', 'sleep'])
 pytz = wrap_module(__import__('pytz'), [
     'utc', 'UTC', 'timezone',
 ])

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -66,6 +66,10 @@ _CONST_OPCODES = set(to_opcodes([
     # 3.6: literal map with constant keys https://bugs.python.org/issue27140
     'BUILD_CONST_KEY_MAP',
     'LIST_EXTEND', 'SET_UPDATE',
+    # 3.11 replace DUP_TOP, DUP_TOP_TWO, ROT_TWO, ROT_THREE, ROT_FOUR
+    'COPY', 'SWAP',
+    # Added in 3.11 https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
+    'RESUME',
 ])) - _BLACKLIST
 
 # operations which are both binary and inplace, same order as in doc'
@@ -88,6 +92,8 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     'DICT_MERGE', 'DICT_UPDATE',
     # Basically used in any "generator literal"
     'GEN_START',  # added in 3.10 but already removed from 3.11.
+    # Added in 3.11, replacing all BINARY_* and INPLACE_*
+    'BINARY_OP',
 ])) - _BLACKLIST
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
@@ -114,6 +120,23 @@ _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
     'LOAD_GLOBAL',
 
     'RERAISE', 'JUMP_IF_NOT_EXC_MATCH',
+
+    # Following opcodes were Added in 3.11
+    # replacement of opcodes CALL_FUNCTION, CALL_FUNCTION_KW, CALL_METHOD
+    'PUSH_NULL', 'PRECALL', 'CALL', 'KW_NAMES',
+    # replacement of POP_JUMP_IF_TRUE and POP_JUMP_IF_FALSE
+    'POP_JUMP_FORWARD_IF_FALSE', 'POP_JUMP_FORWARD_IF_TRUE',
+    'POP_JUMP_BACKWARD_IF_FALSE', 'POP_JUMP_BACKWARD_IF_TRUE',
+    #replacement of JUMP_ABSOLUTE
+    'JUMP_BACKWARD',
+    #replacement of JUMP_IF_NOT_EXC_MATCH
+    'CHECK_EXC_MATCH',
+    # new opcodes
+    'RETURN_GENERATOR',
+    'PUSH_EXC_INFO',
+    'NOP',
+    'FORMAT_VALUE', 'BUILD_STRING'
+
 ])) - _BLACKLIST
 
 _logger = logging.getLogger(__name__)

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -86,6 +86,8 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     # specialised comparisons
     'IS_OP', 'CONTAINS_OP',
     'DICT_MERGE', 'DICT_UPDATE',
+    # Basically used in any "generator literal"
+    'GEN_START',  # added in 3.10 but already removed from 3.11.
 ])) - _BLACKLIST
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([


### PR DESCRIPTION
…compatible with Python 3.9/Werkzeug 0.16

task/5104

Signed-off-by: Rajeesh KV <rajeesh.kv@unipart.com>

Description of the issue/feature this PR addresses: Make odoo work with both Python 3.11/Werkzeug 2.2 and Python 3.9/Werkzeug 0.16

Current behavior before PR: error when running against Python 3.11/Werkzeug 2.2

Desired behavior after PR is merged: works with both Python 3.11/Werkzeug 2.2 and Python 3.9/Werkzeug 0.16


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
