### PR TITLE
SE-483: fix werkzeug 2.x not escaping parenthesis in url encoding

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -46,6 +46,7 @@ try:
     import psutil
 except ImportError:
     psutil = None
+import urllib
 
 import odoo
 from .service.server import memory_info
@@ -1640,7 +1641,8 @@ def send_file(filepath_or_fp, mimetype=None, as_attachment=False, filename=None,
 
 def content_disposition(filename):
     filename = odoo.tools.ustr(filename)
-    escaped = urls.url_quote(filename, safe='')
+    # werkzeug.urls.url_quote 2.x doesn't escape parentheses correctly
+    escaped = urllib.parse.quote(filename, safe='')
 
     return "attachment; filename*=UTF-8''%s" % escaped
 


### PR DESCRIPTION
SE-483

werkzeug.urls.url_quote method in Werkzeug 2.x doesn't escape parentheses, which causes download error if a report attachment has parenthesis in its name (e.g. "Product Label (ZPL).txt").

This method is deprecated and recommended to use urllib.parse.quote instead, as a drop-in replacement.