### PR TITLE
[ADD] graph.py: Ability to set individual modules to have demo data i…

### DIFF
--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -178,7 +178,19 @@ class Node(object):
         return s
 
     def should_have_demo(self):
-        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+        demo_enabled_addons = tools.config.get("demo_enabled_addons", "").split(",")
+        if demo_enabled_addons:
+            # Allow us to enable demo data for specific addons.
+            # For this to be called, ~/.odoorc will need e.g:
+            #
+            # [options]
+            # demo_enabled_addons = stock,sale
+            #
+            # This configuration option should _only_ ever be set in local dev or UAT instances.
+            return self.name in demo_enabled_addons
+        else:
+            # Default (old) Odoo behaviour
+            return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
 
     @property
     def parents(self):


### PR DESCRIPTION
With this change, we can put in an `~/.odoorc` file something like:
```
[options]
demo_enabled_addons = custom_addon1,custom_addon2
```
Then we can define demo data for those addons and _only_ the demo data of the specified addons will load if we have that config set, but not load if the config is unset.
If the config is unset, we let Odoo behave as it would by default.

This MR - when the `demo_enabled_addons` configuration is set - basically ditches odoo's standard handling of demo data, which out of the box just says:
"If you provide the `--without_demo=all` flag then install no demo data - else - install all demo data".

The help text of this flag is very misleading, there's even an open issue about it for odoo 11, and it's still like that in 17!

There is no builtin way of installing it only for specific modules, which doesn't work for us, as we don't care about the core addons demo data (they break stuff).