### PR TITLE
udes-11 suds fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,8 @@ PyYAML==3.13 ; python_version >= '3.7'
 qrcode==7.3.1
 reportlab==3.3.0
 requests==2.11.1
-suds-jurko==0.6
+suds-jurko==0.6 ; python_version < '3.7'
+suds==1.12 ; python_version >= '3.7'
 vatnumber==1.2
 vobject==0.9.3
 Werkzeug==0.11.15


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`suds-jurko` doesn't work with Python 3.7+. Fortunately, there's a community maintained fork at https://pypi.org/project/suds/

Current behavior before PR:
Unable to install gentoo because `base_vat_autocomplete` depends on `suds-jurko` but it fails with error 
```py
File "odoo/addons/base_vat_autocomplete/models/res_partner.py", line 9, in <module>
    from suds.client import Client
  File "py3.7/lib/python3.7/site-packages/suds/__init__.py", line 28, in <module>
    from version import __build__, __version__
ImportError: cannot import name '__build__' from 'version' (py3.7/lib/python3.7/site-packages/version.py)
```

Desired behavior after PR is merged:
Able to install gentoo, using `pip install suds` instead.

