### PR TITLE
[FIX] web: Fallback to UTC on data export when Export All button is used

### DIFF
--- a/addons/web/static/src/js/widgets/data_export.js
+++ b/addons/web/static/src/js/widgets/data_export.js
@@ -176,7 +176,8 @@ var DataExport = Dialog.extend({
                     groupby: this.groupby,
                     context: pyUtils.eval('contexts', [this.record.getContext()]),
                     import_compat: this.isCompatibleMode,
-                    timezone: this.$('.o_export_timezone input').filter(':checked').siblings().text(),
+                    // Fallback to UTC in cases where the o_export_timezone input cannot be found (e.g when 'Export All' button is pressed)
+                    timezone: this.$el === undefined ? 'UTC' : this.$('.o_export_timezone input').filter(':checked').siblings().text()
                 })
             },
             complete: framework.unblockUI,


### PR DESCRIPTION
This element can only be found if the 'Export' action is used. When an 'Export All' button is pressed (e.g on stock.location) then we must use a fallback as any user interaction is bypassed and the export is done immediately.

SE-1824
