### PR TITLE
[REF] odoo: Improve SQL generated for one2many fields.

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -489,6 +489,10 @@ class TestExpression(SavepointCaseWithUserDemo):
         partners = self._search(Partner, [('child_ids.city', '=', 'foo')])
         self.assertFalse(partners)
 
+        # Test aliasing in subquery does not result in invalid query.
+        partners = self.env['res.users'].search([('partner_id.child_ids', '=', False)]).mapped('partner_id')
+        self.assertEqual(len(partners), 2)
+
     def test_15_equivalent_one2many_1(self):
         Company = self.env['res.company']
         company3 = Company.create({'name': 'Acme 3'})
@@ -624,7 +628,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         # Test2: inheritance + relational fields
         users = self._search(Users, [('child_ids.name', 'like', 'test_B')])
         self.assertEqual(users, b1, 'searching through inheritance failed')
-        
+
         # Special =? operator mean "is equal if right is set, otherwise always True"
         users = self._search(Users, [('name', 'like', 'test'), ('parent_id', '=?', False)])
         self.assertEqual(users, a + b1 + b2, '(x =? False) failed')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -141,8 +141,9 @@ DOMAIN_OPERATORS = (NOT_OPERATOR, OR_OPERATOR, AND_OPERATOR)
 # for consistency. This list doesn't contain '<>' as it is simplified to '!='
 # by the normalize_operator() function (so later part of the code deals with
 # only one representation).
-# Internals (i.e. not available to the user) 'inselect' and 'not inselect'
-# operators are also used. In this case its right operand has the form (subselect, params).
+# Internals (i.e. not available to the user) 'inselect', 'not inselect',
+# 'exists' and 'not exists' operators are also used. In this case its right operand
+# has the form (subselect, params).
 TERM_OPERATORS = ('=', '!=', '<=', '<', '>', '>=', '=?', '=like', '=ilike',
                   'like', 'not like', 'ilike', 'not ilike', 'in', 'not in',
                   'child_of', 'parent_of')
@@ -373,14 +374,14 @@ def is_leaf(element, internal=False):
         - second element if a valid op
 
         :param tuple element: a leaf in form (left, operator, right)
-        :param boolean internal: allow or not the 'inselect' internal operator
-            in the term. This should be always left to False.
+        :param boolean internal: allow or not the 'inselect' or 'exists'
+            internal operator in the term. This should be always left to False.
 
         Note: OLD TODO change the share wizard to use this function.
     """
     INTERNAL_OPS = TERM_OPERATORS + ('<>',)
     if internal:
-        INTERNAL_OPS += ('inselect', 'not inselect')
+        INTERNAL_OPS += ('inselect', 'not inselect', 'exists', 'not exists')
     return (isinstance(element, tuple) or isinstance(element, list)) \
         and len(element) == 3 \
         and element[1] in INTERNAL_OPS \
@@ -778,8 +779,13 @@ class expression(object):
                 else:
                     if comodel._fields[field.inverse_name].store and not (inverse_is_int and domain):
                         # rewrite condition to match records with/without lines
-                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
-                        subquery = 'SELECT "%s" FROM "%s" where "%s" is not null' % (field.inverse_name, comodel._table, field.inverse_name)
+                        op1 = 'exists' if operator in NEGATIVE_TERM_OPERATORS else 'not exists'
+                        # Alias the table in the subquery to handle the case
+                        # where the table has a foreign key on itself (model == comodel)
+                        subquery_alias = comodel._table + '__ALIAS'
+                        # Double-escape the FROM TABLE placeholder so that it
+                        # can be replaced by an alias when SQL is generated.
+                        subquery = 'SELECT 1 FROM "%s" "%s" where "%s"."%s" = %%s."%s"' % (comodel._table, subquery_alias, subquery_alias, field.inverse_name, 'id')
                         push(('id', op1, (subquery, [])), model, alias, internal=True)
                     else:
                         comodel_domain = [(field.inverse_name, '!=', False)]
@@ -945,7 +951,7 @@ class expression(object):
         left, operator, right = leaf
 
         # final sanity checks - should never fail
-        assert operator in (TERM_OPERATORS + ('inselect', 'not inselect')), \
+        assert operator in (TERM_OPERATORS + ('inselect', 'not inselect', 'exists', 'not exists')), \
             "Invalid operator %r in domain term %r" % (operator, leaf)
         assert leaf in (TRUE_LEAF, FALSE_LEAF) or left in model._fields, \
             "Invalid field %r in domain term %r" % (left, leaf)
@@ -969,6 +975,14 @@ class expression(object):
         elif operator == 'not inselect':
             query = '(%s."%s" not in (%s))' % (table_alias, left, right[0])
             params = list(right[1])
+
+        elif operator == 'exists':
+            query = '(EXISTS (%s))' % (right[0] % table_alias)
+            params = right[1]
+
+        elif operator == 'not exists':
+            query = '(NOT EXISTS (%s))' % (right[0] % table_alias)
+            params = right[1]
 
         elif operator in ['in', 'not in']:
             # Two cases: right is a boolean or a list. The boolean case is an


### PR DESCRIPTION
SE-2075

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

Odoo's handling of domain criteria of the form

`('fk_column', '=', False)`

is inefficient.  It creates subqueries tha compute all the ids in the child table which can require considerable resources to compute if the child table is large.

This patch changes the expression parser to accept 'exists' and 'not exists' as internal operators and uses them in place of 'inselect' and 'not inselect' when computing domain criteria of the form

`('fk_column', '=', False)`

This is a forward port of
https://github.com/unipartdigital/odoo/commit/e03f90373894f265beae3eeae362726f0f259f8e

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
