### PR TITLE
[FIX] odoo: Inventory at date bug

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1913,6 +1913,8 @@ class Datetime(Field):
                 return value
             return datetime.combine(value, time.min)
 
+        # Remove fractional if exists, by splitting with "."
+        value = value.split(".")[0]
         # TODO: fix data files
         return datetime.strptime(value, DATETIME_FORMAT[:len(value)-2])
 


### PR DESCRIPTION
- Remove fractional value from datetime

SE-2760

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
